### PR TITLE
Update Magenta ANSI code

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Helpers/Beaprint.cs
+++ b/winPEAS/winPEASexe/winPEAS/Helpers/Beaprint.cs
@@ -17,7 +17,7 @@ namespace winPEAS.Helpers
         static string LYELLOW = "\x1b[1;33m";
         static string BLUE = "\x1b[34m";
         public static string LBLUE = "\x1b[1;34m";
-        static string MAGENTA = "\x1b[1:35m";
+        static string MAGENTA = "\x1b[1;35m";
         //static string LMAGENTA = "\x1b[1;35m";
         static string CYAN = "\x1b[36m";
         static string LCYAN = "\x1b[1;36m";


### PR DESCRIPTION
Updating the colon to a semi-colon in order to properly print the item following the code in Magenta. Currently, it prints out the text, but does not put the item in the color.

Reference: https://bixense.com/clicolors/ and also the LMAGENTA ANSI code below MAGENTA.

Thanks!