### PR TITLE
More robust implementation of pkexec binary modification time check

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information.sh
@@ -22,7 +22,7 @@ fi
 echo ""
 
 #-- SY) CVE-2021-4024
-if [ `command -v pkexec` ] && stat -c '%a' $(which pkexec) | grep -q 4755 && (stat -c '%y' $(which pkexec) | grep -qvE "2[0-9][2-9][3-9]-|2022-[0-1][2-9]-0[0-9]|2022-01-[2-3][0-9]|2022-01-1[2-9]" ) ; then 
+if [ `command -v pkexec` ] && stat -c '%a' $(which pkexec) | grep -q 4755 && [ "$(stat -c '%Y' $(which pkexec))" -lt "1642035600" ]; then 
     echo "Vulnerable to CVE-2021-4024 (polkit privesc)" | sed -${E} "s,.*,${SED_RED_YELLOW},"
 fi
 

--- a/linPEAS/builder/linpeas_parts/1_system_information.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information.sh
@@ -21,9 +21,9 @@ else echo_not_found "sudo"
 fi
 echo ""
 
-#-- SY) CVE-2021-4024
+#-- SY) CVE-2021-4034
 if [ `command -v pkexec` ] && stat -c '%a' $(which pkexec) | grep -q 4755 && [ "$(stat -c '%Y' $(which pkexec))" -lt "1642035600" ]; then 
-    echo "Vulnerable to CVE-2021-4024 (polkit privesc)" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+    echo "Vulnerable to CVE-2021-4034 (polkit privesc)" | sed -${E} "s,.*,${SED_RED_YELLOW},"
 fi
 
 #--SY) USBCreator


### PR DESCRIPTION
More robust implementation of pkexec binary modification time check with integer comparison instead of date regex grep.

1642035600 == Thursday, January 13, 2022 1:00:00 AM
Which is when it was first patched. We have to check this way because the polkit version number is the same, patched & unpatched.