### PR TITLE
Improved CVE-2021-3560 Check

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information.sh
@@ -29,7 +29,7 @@ fi
 
 #-- SY) CVE-2021-3560
 polkitVersion=$(systemctl status polkit.service | grep version | cut -d " " -f 9)
-if [[ "$(apt list --installed 2>/dev/null | grep polkit | grep -c 0.105-26)" -ge 1 || "$(yum list installed | grep polkit | grep -c 0.117-2)" -ge 1 ]]; then
+if [[ "$(apt list --installed 2>/dev/null | grep polkit | grep -c 0.105-26)" -ge 1 || "$(rpm -qa | grep polkit | grep -c '0.117-2\|0.115-6')" -ge 1 ]]; then
     echo "Vulnerable to CVE-2021-3560" | sed -${E} "s,.*,${SED_RED_YELLOW},"
     echo ""
 fi


### PR DESCRIPTION
* Swapped `yum ` for `rpm ` for improved compatibility 
* Added known vulnerable version of Polkit