### PR TITLE
Fixed typo that caused linux-exploit-suggester results not being displayed

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information.sh
@@ -138,7 +138,7 @@ if [ "$(command -v bash 2>/dev/null)" ]; then
     if [ "$EXTRA_CHECKS" ]; then
         echo $les_b64 | base64 -d | bash -s -- --checksec | sed "s,$(printf '\033')\\[[0-9;]*[a-zA-Z],,g" | sed -E "s,\[CVE-[0-9]+-[0-9]+\].*,${SED_RED},g"
     else
-        echo $les_b64 | base64 -d | bash | sed "s,$(printf '\033')\\[[0-9;]*[a-zA-Z],,g" | grep -i "\[CVE" -A 10 | grep -Ev "^\-\-$" | sed -${E} "s,\[CVE-[0-9]+-[0-9]+\],*,${SED_RED},g"
+        echo $les_b64 | base64 -d | bash | sed "s,$(printf '\033')\\[[0-9;]*[a-zA-Z],,g" | grep -i "\[CVE" -A 10 | grep -Ev "^\-\-$" | sed -${E} "s,\[CVE-[0-9]+-[0-9]+\].*,${SED_RED},g"
     fi
     echo ""
 fi


### PR DESCRIPTION
A regex has a typo which results in the following error when `linpeas.sh` is run:

```
╔══════════╣ Executing Linux Exploit Suggester
╚ https://github.com/mzet-/linux-exploit-suggester                                                                                                                                                               
sed: -e expression #1, char 27: unknown option to `s'  
```

Thus the linux-exploit-suggester results are no longer displayed.

Replaced a comma with a period to fix the problem.