### PR TITLE
Add search for .cmd files

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/FilesInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/FilesInfo.cs
@@ -747,7 +747,8 @@ namespace winPEAS.Checks
             {
                 ".bat",
                 ".exe",
-                ".ps1"
+                ".ps1",
+                ".cmd"
             };
 
             var files = SearchHelper.GetFilesFast(systemDrive, "*", excludedDirs);            


### PR DESCRIPTION
Since `.cmd` files are batch files too, IMHO they should be included in the search for interesting files.

The same thing could probably be said for `.SUB` and `.BTM`, but I've never seen them in the wild. Can add them too tho, if desired. 