### PR TITLE
Fixing Issue 305 Potentially unnecessary ╚ character #305

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Helpers/Beaprint.cs
+++ b/winPEAS/winPEASexe/winPEAS/Helpers/Beaprint.cs
@@ -180,7 +180,7 @@ namespace winPEAS.Helpers
         {
             // print_info
             //Console.WriteLine(YELLOW + "   [?] " + LBLUE + comment + " " + LYELLOW + link + NOCOLOR);            
-            Console.WriteLine($"{LCYAN}╚ {LBLUE}{comment} {LYELLOW}{link}{NOCOLOR}");
+            Console.WriteLine($"{LCYAN}{LBLUE}{comment} {LYELLOW}{link}{NOCOLOR}");
         }
 
         public static void InfoPrint(string toPrint)


### PR DESCRIPTION
Removing ╚ Before intro text : "You can find a Windows local PE Checklist here: https://book.hacktricks.xyz/windows-hardening/checklist-windows-privilege-escalation "
╚ is not in a section so it causes trouble. We don't need it here. It's not present in linpeas output