### PR TITLE
Check "doas.conf" based on binary existence, not configuration files

### DIFF
--- a/linPEAS/builder/linpeas_parts/6_users_information.sh
+++ b/linPEAS/builder/linpeas_parts/6_users_information.sh
@@ -105,7 +105,7 @@ fi
 echo ""
 
 #-- UI) Doas
-if [ -f "/etc/doas.conf" ] || [ "$DEBUG" ]; then
+if [ "$(command -v doas 2>/dev/null)" ] || [ "$DEBUG" ]; then
   print_2title "Checking doas.conf"
   doas_dir_name=$(dirname "$(command -v doas)" 2>/dev/null)
   if [ "$(cat /etc/doas.conf $doas_dir_name/doas.conf $doas_dir_name/../etc/doas.conf $doas_dir_name/etc/doas.conf 2>/dev/null)" ]; then 


### PR DESCRIPTION
Existing "cat" file scan successfully locates [ "/usr/local/etc/doas.conf"](https://www.freebsd.org/cgi/man.cgi?query=doas.conf) **with Debug flag set.**

However it doesn't get run at all without debug as the prerequisite check is for "/etc/doas.conf", regardless of the existence of the "doas" binary within PATH 
