### PR TITLE
Fix a bug of finding readable files in sudoers.d

### DIFF
--- a/linPEAS/builder/linpeas_parts/6_users_information.sh
+++ b/linPEAS/builder/linpeas_parts/6_users_information.sh
@@ -68,7 +68,7 @@ fi
 if ! [ "$IAMROOT" ] && [ -w '/etc/sudoers.d/' ]; then
   echo "You can create a file in /etc/sudoers.d/ and escalate privileges" | sed -${E} "s,.*,${SED_RED_YELLOW},"
 fi
-for filename in '/etc/sudoers.d/*'; do
+for filename in /etc/sudoers.d/*; do
   if [ -r "$filename" ]; then
     echo "Sudoers file: $filename is readable" | sed -${E} "s,.*,${SED_RED},g"
     grep -Iv "^$" "$filename" | grep -v "#" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g" | sed "s,pwfeedback,${SED_RED},g" 


### PR DESCRIPTION
Fix a bug of finding user readable files in /etc/sudoers.d
```bash
for filename in /etc/sudoers.d/*; do
    ...  # $filename is an array
done
```

```bash
for filename in '/etc/sudoers.d/*'; do
    ...  # $filename is a single long string
done
```