### PR TITLE
sensitive_files.yaml(SNMP) add createUser to bad_regex

### DIFF
--- a/build_lists/sensitive_files.yaml
+++ b/build_lists/sensitive_files.yaml
@@ -2123,7 +2123,7 @@ search:
         files:
           - name: "snmpd.conf"
             value: 
-                bad_regex: "rocommunity|rwcommunity|extend.*"
+                bad_regex: "rocommunity|rwcommunity|extend.*|^createUser"
                 only_bad_lines: True
                 type: f
                 search_in: 


### PR DESCRIPTION
Add `createUser` to `bad_regex` as it likely contains a hardcoded password.

As an example:
```
createUser bootstrap MD5 SuperSecurePassword123__ DES
```
where `SuperSecurePassword123__` is the password and `bootstrap` is the username, though I should mention the username maybe misleading here.

Spec/Man-page link:
[freebsd.org - snmpd.conf]

[freebsd.org - snmpd.conf]: https://man.freebsd.org/cgi/man.cgi?query=snmpd.conf#:~:text=your%2D%0A%20%20%20%20%20%20%20self%20instead%3A-,createUser,-%5B%2De%09%20%20%20%20%20%20%20ENGINEID%5D%09%20%20%20%20%20%20username