### PR TITLE
change outdir for build in solution and dotfuscator config

### DIFF
--- a/winPEAS/winPEASexe/README.md
+++ b/winPEAS/winPEASexe/README.md
@@ -121,14 +121,15 @@ In order to compile an **ofuscated version** of Winpeas and bypass some AVs you 
 
 To install it *open VisualStudio --> Go to Search (CTRL+Q) --> Write "dotfuscator"* and just follow the instructions to install it.
 
-To use **dotfuscator** you will need to **create an account** *(they will send you an email to the address you set during registration*).
+To use **dotfuscator** you can **create an account** *(they will send you an email to the address you set during registration*) to get access to updates and some additional features. It is also possible to skip that step and obfuscate winPEAS, just hit `cancel`.
 
 Once you have installed and activated it you need to:
-1. **Compile** winpeas in VisualStudio
+1. **Compile** winpeas in VisualStudio, for Release
 2. **Open dotfuscator** app
-3. **Open** in dotfuscator **winPEAS.exe compiled**
+3. **Open the dotfuscator config** from `binaries/Obfuscated Releases/<architecture>`
+    - replace `architecture` with the architecture, which you compiled (x86, x86, any)
 4. Click on **Build**
-5. The **single, minimized and obfuscated binary** will appear in a **folder called Dotfuscator inside the folder were winPEAS.exe** and the DLL were (this location will be saved by dotfuscator and by default all the following builds will appear in this folder).
+5. The **single, minimized and obfuscated binary** will appear in `binaries/Obfuscated Releases/Dotfuscated/<architectur>` and the DLL were (this location will be saved by dotfuscator and by default all the following builds will appear in this folder).
 
 **I'm sorry that all of this is necessary but is worth it. Dotfuscator minimizes a bit the size of the executable and obfuscates the code**.
 

--- a/winPEAS/winPEASexe/binaries/Obfuscated Releases/any.xml
+++ b/winPEAS/winPEASexe/binaries/Obfuscated Releases/any.xml
@@ -14,7 +14,7 @@
         <option>stripoa</option>
         <option>library</option>
         <option>transformxaml</option>
-        <file dir="winPEAS\winPEASexe\binaries\Release" name="winPEASany.exe" />
+        <file dir="binaries\Release" name="winPEAS.exe" />
       </inputassembly>
     </asmlist>
   </input>

--- a/winPEAS/winPEASexe/binaries/Obfuscated Releases/x64.xml
+++ b/winPEAS/winPEASexe/binaries/Obfuscated Releases/x64.xml
@@ -14,7 +14,7 @@
         <option>stripoa</option>
         <option>library</option>
         <option>transformxaml</option>
-        <file dir="winPEAS\winPEASexe\binaries\x64\Release" name="winPEASx64.exe" />
+        <file dir="binaries\x64\Release" name="winPEAS.exe" />
       </inputassembly>
     </asmlist>
   </input>

--- a/winPEAS/winPEASexe/binaries/Obfuscated Releases/x86.xml
+++ b/winPEAS/winPEASexe/binaries/Obfuscated Releases/x86.xml
@@ -14,7 +14,7 @@
         <option>stripoa</option>
         <option>library</option>
         <option>transformxaml</option>
-        <file dir="winPEAS\winPEASexe\binaries\x86\Release" name="winPEASx86.exe" />
+        <file dir="binaries\x86\Release" name="winPEAS.exe" />
       </inputassembly>
     </asmlist>
   </input>

--- a/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
+++ b/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
@@ -47,7 +47,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\binaries\Release</OutputPath>
     <DefineConstants>TRUE WIN32 _MSC_VER NDEBUG NO_TCL SQLITE_ASCII SQLITE_DISABLE_LFS SQLITE_ENABLE_OVERSIZE_CELL_CHECK SQLITE_MUTEX_OMIT SQLITE_OMIT_AUTHORIZATION SQLITE_OMIT_DEPRECATED SQLITE_OMIT_GET_TABLE SQLITE_OMIT_INCRBLOB SQLITE_OMIT_LOOKASIDE SQLITE_OMIT_SHARED_CACHE SQLITE_OMIT_UTF16 SQLITE_OMIT_VIRTUALTABLE SQLITE_OS_WIN SQLITE_SYSTEM_MALLOC VDBE_PROFILE_OFF</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -74,7 +74,7 @@
     <NoWarn>0168 ; 0169; 0414; 0618; 0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
+    <OutputPath>..\binaries\x64\Release\</OutputPath>
     <DefineConstants>TRUE WIN32 _MSC_VER NDEBUG NO_TCL SQLITE_ASCII SQLITE_DISABLE_LFS SQLITE_ENABLE_OVERSIZE_CELL_CHECK SQLITE_MUTEX_OMIT SQLITE_OMIT_AUTHORIZATION SQLITE_OMIT_DEPRECATED SQLITE_OMIT_GET_TABLE SQLITE_OMIT_INCRBLOB SQLITE_OMIT_LOOKASIDE SQLITE_OMIT_SHARED_CACHE SQLITE_OMIT_UTF16 SQLITE_OMIT_VIRTUALTABLE SQLITE_OS_WIN SQLITE_SYSTEM_MALLOC VDBE_PROFILE_OFF</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -98,7 +98,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
+    <OutputPath>..\binaries\x86\Release\</OutputPath>
     <DefineConstants>TRUE WIN32 _MSC_VER NDEBUG NO_TCL SQLITE_ASCII SQLITE_DISABLE_LFS SQLITE_ENABLE_OVERSIZE_CELL_CHECK SQLITE_MUTEX_OMIT SQLITE_OMIT_AUTHORIZATION SQLITE_OMIT_DEPRECATED SQLITE_OMIT_GET_TABLE SQLITE_OMIT_INCRBLOB SQLITE_OMIT_LOOKASIDE SQLITE_OMIT_SHARED_CACHE SQLITE_OMIT_UTF16 SQLITE_OMIT_VIRTUALTABLE SQLITE_OS_WIN SQLITE_SYSTEM_MALLOC VDBE_PROFILE_OFF</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
According to the docs and the dotfuscator config, the outdir should be under `winPEASexe/binaries` and not `winPEASexe/winPEAS/bin`.
This makes it so, that no user changes are necessary for dotfuscator usage.
Also improves the docs a bit.