### PR TITLE
SNMP: Added createUser

### DIFF
--- a/build_lists/sensitive_files.yaml
+++ b/build_lists/sensitive_files.yaml
@@ -2123,7 +2123,7 @@ search:
         files:
           - name: "snmpd.conf"
             value: 
-                bad_regex: "rocommunity|rwcommunity|extend.*"
+                bad_regex: "rocommunity|rwcommunity|^createUser|extend.*"
                 only_bad_lines: True
                 type: f
                 search_in: 


### PR DESCRIPTION
In HackTheBox: Mentor, linpeas didn't find the creds in `\etc\snmp\snmpd.conf`, I've modified it, thanks to ippsec video..