### PR TITLE
Fix command not found error

### DIFF
--- a/linPEAS/builder/linpeas_base.sh
+++ b/linPEAS/builder/linpeas_base.sh
@@ -3378,7 +3378,7 @@ peass{NFS Exports}
 kadmin_exists="$(command -v kadmin)"
 klist_exists="$(command -v klist)"
 kinit_exists="$(command -v kinit)"
-if [ "$kadmin_exists" ] || [ "$klist_exists" ] || [ "$kinit_exists" ] || [ "$PSTORAGE_KERBEROS" ] || [ "$DEBUG" ]; then
+if [ "$kadmin_exists" ] || [ "$klist_exists" ] || [ "$kinit_exists" ] || [ "$PSTORAGE_KERBEROS" ] || [ "$DEBUG" ]; then
   print_2title "Searching kerberos conf files and tickets"
   print_info "http://book.hacktricks.xyz/linux-hardening/privilege-escalation/linux-active-directory"
 

--- a/linPEAS/builder/linpeas_parts/7_software_information.sh
+++ b/linPEAS/builder/linpeas_parts/7_software_information.sh
@@ -326,7 +326,7 @@ peass{NFS Exports}
 kadmin_exists="$(command -v kadmin)"
 klist_exists="$(command -v klist)"
 kinit_exists="$(command -v kinit)"
-if [ "$kadmin_exists" ] || [ "$klist_exists" ] || [ "$kinit_exists" ] || [ "$PSTORAGE_KERBEROS" ] || [ "$DEBUG" ]; then
+if [ "$kadmin_exists" ] || [ "$klist_exists" ] || [ "$kinit_exists" ] || [ "$PSTORAGE_KERBEROS" ] || [ "$DEBUG" ]; then
   print_2title "Searching kerberos conf files and tickets"
   print_info "http://book.hacktricks.xyz/linux-hardening/privilege-escalation/linux-active-directory"
 


### PR DESCRIPTION
The following error occurred when evaluating the expression because the space that should have been a space was U+0a00.

```
./linpeas.sh: 3672: ./linpeas.sh:  [: not found
```