### PR TITLE
fix su brute check.

### DIFF
--- a/linPEAS/builder/linpeas_parts/6_users_information.sh
+++ b/linPEAS/builder/linpeas_parts/6_users_information.sh
@@ -25,7 +25,7 @@ if [ "$MACPEAS" ];then
 
   print_2title "SystemKey"
   ls -l /var/db/SystemKey
-  if [ -r "/var/db/SystemKey" ]; then 
+  if [ -r "/var/db/SystemKey" ]; then
     echo "You can read /var/db/SystemKey" | sed -${E} "s,.*,${SED_RED_YELLOW},";
     hexdump -s 8 -n 24 -e '1/1 "%.2x"' /var/db/SystemKey | sed -${E} "s,.*,${SED_RED_YELLOW},";
   fi
@@ -71,7 +71,7 @@ fi
 for filename in /etc/sudoers.d/*; do
   if [ -r "$filename" ]; then
     echo "Sudoers file: $filename is readable" | sed -${E} "s,.*,${SED_RED},g"
-    grep -Iv "^$" "$filename" | grep -v "#" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g" | sed "s,pwfeedback,${SED_RED},g" 
+    grep -Iv "^$" "$filename" | grep -v "#" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g" | sed "s,pwfeedback,${SED_RED},g"
   fi
 done
 echo ""
@@ -80,17 +80,17 @@ echo ""
 print_2title "Checking sudo tokens"
 print_info "https://book.hacktricks.xyz/linux-hardening/privilege-escalation#reusing-sudo-tokens"
 ptrace_scope="$(cat /proc/sys/kernel/yama/ptrace_scope 2>/dev/null)"
-if [ "$ptrace_scope" ] && [ "$ptrace_scope" -eq 0 ]; then 
+if [ "$ptrace_scope" ] && [ "$ptrace_scope" -eq 0 ]; then
   echo "ptrace protection is disabled (0), so sudo tokens could be abused" | sed "s,is disabled,${SED_RED},g";
-  
-  if [ "$(command -v gdb 2>/dev/null)" ]; then 
+
+  if [ "$(command -v gdb 2>/dev/null)" ]; then
     echo "gdb was found in PATH" | sed -${E} "s,.*,${SED_RED},g";
   fi
-  
-  if [ "$CURRENT_USER_PIVOT_PID" ]; then 
+
+  if [ "$CURRENT_USER_PIVOT_PID" ]; then
     echo "The current user proc $CURRENT_USER_PIVOT_PID is the parent of a different user proccess" | sed -${E} "s,.*,${SED_RED},g";
   fi
-  
+
   if [ -f "$HOME/.sudo_as_admin_successful" ]; then
     echo "Current user has .sudo_as_admin_successful file, so he can execute with sudo" | sed -${E} "s,.*,${SED_RED},";
   fi
@@ -100,7 +100,7 @@ if [ "$ptrace_scope" ] && [ "$ptrace_scope" -eq 0 ]; then
     ps -eo pid,command -u "$(id -u)" | grep -v "$PPID" | grep -v " " | grep -E '(ash|ksh|csh|dash|bash|zsh|tcsh|sh)$'
   fi
 
-else 
+else
   echo "ptrace protection is enabled ($ptrace_scope)" | sed "s,is enabled,${SED_GREEN},g";
 
 fi
@@ -110,7 +110,7 @@ echo ""
 if [ -f "/etc/doas.conf" ] || [ "$DEBUG" ]; then
   print_2title "Checking doas.conf"
   doas_dir_name=$(dirname "$(command -v doas)" 2>/dev/null)
-  if [ "$(cat /etc/doas.conf $doas_dir_name/doas.conf $doas_dir_name/../etc/doas.conf $doas_dir_name/etc/doas.conf 2>/dev/null)" ]; then 
+  if [ "$(cat /etc/doas.conf $doas_dir_name/doas.conf $doas_dir_name/../etc/doas.conf $doas_dir_name/etc/doas.conf 2>/dev/null)" ]; then
     cat /etc/doas.conf "$doas_dir_name/doas.conf" "$doas_dir_name/../etc/doas.conf" "$doas_dir_name/etc/doas.conf" 2>/dev/null | sed -${E} "s,$sh_usrs,${SED_RED}," | sed "s,root,${SED_RED}," | sed "s,nopass,${SED_RED}," | sed -${E} "s,$nosh_usrs,${SED_BLUE}," | sed "s,$USER,${SED_RED_YELLOW},"
   else echo_not_found "doas.conf"
   fi
@@ -214,8 +214,7 @@ if [ "$EXTRA_CHECKS" ]; then
 fi
 
 #-- UI) Brute su
-EXISTS_SUDO="$(command -v sudo 2>/dev/null)"
-if ! [ "$FAST" ] && ! [ "$SUPERFAST" ] && [ "$TIMEOUT" ] && ! [ "$IAMROOT" ] && [ "$EXISTS_SUDO" ]; then
+if ! [ "$FAST" ] && ! [ "$SUPERFAST" ] && [ "$TIMEOUT" ] && ! [ "$IAMROOT" ]; then
   print_2title "Testing 'su' as other users with shell using as passwords: null pwd, the username and top2000pwds\n"$NC
   POSSIBE_SU_BRUTE=$(check_if_su_brute);
   if [ "$POSSIBE_SU_BRUTE" ]; then
@@ -228,6 +227,6 @@ if ! [ "$FAST" ] && ! [ "$SUPERFAST" ] && [ "$TIMEOUT" ] && ! [ "$IAMROOT" ] && 
     printf $GREEN"It's not possible to brute-force su.\n\n"$NC
   fi
 else
-  print_2title "Do not forget to test 'su' as any other user with shell: without password and with their names as password (I can't do it...)\n"$NC
+  print_2title "Do not forget to test 'su' as any other user with shell: without password and with their names as password (I don't do it in FAST mode...)\n"$NC
 fi
 print_2title "Do not forget to execute 'sudo -l' without password or with valid password (if you know it)!!\n"$NC


### PR DESCRIPTION
Currently, the 'su' brute check is never performed when 'sudo' is not found by `command -v sudo`. Since sudo is not required for 'su' brute, I removed that and replaced it with a check for 'su'. This ensures the su brute check will correctly be performed even when sudo is not found.

Additionally, the help message printed for command line args didn't include the `-a` flag that invokes all checks and unsets "FAST" mode, which is required for the su brute check to be invoked.

Note, my code editor automatically removes trailing white space, so several extra lines appear to change due to that. The significant changes are in:
- builder/linpeas_parts/linpeas_base.sh:748-751 and 77
- builder/linpeas_parts/6_users_information.sh:217-230 