### PR TITLE
Fixed winPEAS download string

### DIFF
--- a/winPEAS/winPEASps1/README.md
+++ b/winPEAS/winPEASps1/README.md
@@ -15,7 +15,7 @@ The official **maintainer of this script is [RandolphConley](https://github.com/
 Download the **[latest releas from here](https://github.com/carlospolop/PEASS-ng/releases/latest)**.
 
 ```bash
-powershell "IEX(New-Object Net.WebClient).downloadString('https://raw.githubusercontent.com/carlospolop/PEASS-ng/master/winPEAS/winPEASps1/WinPeas.ps1')"
+powershell "IEX(New-Object Net.WebClient).downloadString('https://raw.githubusercontent.com/carlospolop/PEASS-ng/master/winPEAS/winPEASps1/winPEAS.ps1')"
 ```
 
 ## Advisory


### PR DESCRIPTION
The download string is case-sensitive, and 404s when using the wrong link.