### PR TITLE
Fix linPEAS build

### DIFF
--- a/linPEAS/builder/src/linpeasBuilder.py
+++ b/linPEAS/builder/src/linpeasBuilder.py
@@ -353,7 +353,7 @@ class LinpeasBuilder:
     
     def __get_gtfobins_lists(self) -> tuple:
         r = requests.get("https://github.com/GTFOBins/GTFOBins.github.io/tree/master/_gtfobins")
-        bins = re.findall(r'/GTFOBins/GTFOBins.github.io/blob/master/_gtfobins/([\w_ \-]+).md', r.text)
+        bins = re.findall(r'_gtfobins/([\w_ \-]+).md', r.text)
 
         sudoVB = []
         suidVB = []


### PR DESCRIPTION
The Build linpeas step of the Build_and_test_linpeas_master job (CI-master_test action) failed because of an assertion error (see [Build_and_test_linpeas_master logs](https://github.com/carlospolop/PEASS-ng/actions/runs/5613096215/job/15208340195#logs)).

```bash
python3 -m builder.linpeas_builder
[...]
[+] Building GTFOBins lists...
Len bins is 0
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "[...]/PEASS-ng/linPEAS/builder/linpeas_builder.py", line 33, in <module>
    main()
  File "[...]/PEASS-ng/linPEAS/builder/linpeas_builder.py", line 20, in main
    lbuilder.build()
  File "[...]/PEASS-ng/linPEAS/builder/src/linpeasBuilder.py", line 113, in build
    assert len(suidVB) > 185, f"Len suidVB is {len(suidVB)}"
           ^^^^^^^^^^^^^^^^^
AssertionError: Len suidVB is 0
```

The root cause can be found in the `re.findall` instruction of the `__get_gtfobins_lists` method. Indeed, with the following command, we can see that there is no `/GTFOBins/GTFOBins.github.io/blob/master/_gtfobins/([\w_ \-]+).md` in the response anymore: 

```bash
curl https://github.com/GTFOBins/GTFOBins.github.io/tree/master/_gtfobins | grep --color "/GTFOBins/GTFOBins.github.io/blob/master/_gtfobins"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 28955  100 28955    0     0  76859      0 --:--:-- --:--:-- --:--:-- 76803
```
However, the response content does include the following:

```bash
[...]"tree":{"items":[[...],{"name":"7z.md","path":"_gtfobins/7z.md","contentType":"file"},[...]
```

So, I just updated the pattern of the `findall` method:

```python
bins = re.findall(r'_gtfobins/([\w_ \-]+).md', r.text)
```

Result:
```bash
python3 -m builder.linpeas_builder
[+] Downloading regexes...
Downloaded and saved in '[...]/PEASS-ng/build_lists/regexes.yaml' successfully!
[+] Building temporary linpeas_base.sh...
[+] Building variables...
[+] Building finds...
[+] Building storages...
[+] Checking duplicates...
[+] Building autocheck sections...
[+] Building regexes searches...
[+] Building linux exploit suggesters...
[+] Downloading Fat Linpeas binaries...
LICENSE
README.md
gitleaks
LICENSE
README.md
gitleaks
[+] Building GTFOBins lists...
[+] Final sanity checks...
```

```bash
ls 
builder  images  linpeas_fat.sh  linpeas.sh  README.md  TODO.md
```