### PR TITLE
Fixed Typo in Readme for linPEASS

### DIFF
--- a/linPEAS/README.md
+++ b/linPEAS/README.md
@@ -95,7 +95,7 @@ By default linpeas takes around **4 mins** to complete, but It could take from *
 **Interesting parameters:**
 - **-a** (all checks except regex) - This will **execute also the check of processes during 1 min, will search more possible hashes inside files, and brute-force each user using `su` with the top2000 passwords.**
 - **-e** (extra enumeration) - This will execute **enumeration checkes that are avoided by default**
-- **-r** (regex checks) - This will search for **hundreds of API keys of different platforms in the silesystem**
+- **-r** (regex checks) - This will search for **hundreds of API keys of different platforms in the Filesystem**
 - **-s** (superfast & stealth) - This will bypass some time consuming checks - **Stealth mode** (Nothing will be written to disk)
 - **-P** (Password) - Pass a password that will be used with `sudo -l` and bruteforcing other users
 - **-D** (Debug) - Print information about the checks that haven't discovered anything and about the time each check took


### PR DESCRIPTION
In the Readme there was a "silesystem" instead of "filesystem".