### PR TITLE
Update linpeas_builder.py

### DIFF
--- a/linPEAS/builder/linpeas_builder.py
+++ b/linPEAS/builder/linpeas_builder.py
@@ -1,7 +1,7 @@
-from .src.peasLoaded import PEASLoaded
-from .src.linpeasBuilder import LinpeasBuilder
-from .src.linpeasBaseBuilder import LinpeasBaseBuilder
-from .src.yamlGlobals import FINAL_FAT_LINPEAS_PATH, FINAL_LINPEAS_PATH, TEMPORARY_LINPEAS_BASE_PATH
+from src.peasLoaded import PEASLoaded
+from src.linpeasBuilder import LinpeasBuilder
+from src.linpeasBaseBuilder import LinpeasBaseBuilder
+from src.yamlGlobals import FINAL_FAT_LINPEAS_PATH, FINAL_LINPEAS_PATH, TEMPORARY_LINPEAS_BASE_PATH
 
 import os
 import stat


### PR DESCRIPTION
The old version of file was not running on python 3.11.5.  The error was:
from .src.peasLoaded import PEASLoaded
ImportError: attempted relative import with no known parent package