### PR TITLE
Better error handling in FileAnalysis

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/FileAnalysis.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/FileAnalysis.cs
@@ -444,7 +444,7 @@ namespace winPEAS.Checks
                                             foundRegexes[regex_obj.name][regex.name] = fileResults;
                                         }
                                     }
-                                    catch (System.IO.IOException)
+                                    catch (Exception ex)
                                     {
                                         // Cannot read the file
                                     }


### PR DESCRIPTION
The previous specific check doesn't handle the following exception, causing it to be catched by the last try/catch block.

Error looking for regexes inside files: System.AggregateException: One or more errors occurred. ---> System.UnauthorizedAccessException: Access to the path '\<REDACTED>' is denied.