### PR TITLE
fix typo in 'run unshare' container check

### DIFF
--- a/linPEAS/builder/linpeas_parts/2_container.sh
+++ b/linPEAS/builder/linpeas_parts/2_container.sh
@@ -324,7 +324,7 @@ if [ "$inContainer" ]; then
     checkProcSysBreakouts
     print_list "/proc mounted? ................. $proc_mounted\n" | sed -${E} "s,Yes,${SED_RED_YELLOW},"
     print_list "/dev mounted? .................. $dev_mounted\n" | sed -${E} "s,Yes,${SED_RED_YELLOW},"
-    print_list "Run ushare ..................... $run_unshare\n" | sed -${E} "s,Yes,${SED_RED},"
+    print_list "Run unshare .................... $run_unshare\n" | sed -${E} "s,Yes,${SED_RED},"
     print_list "release_agent breakout 1........ $release_agent_breakout1\n" | sed -${E} "s,Yes,${SED_RED},"
     print_list "release_agent breakout 2........ $release_agent_breakout2\n" | sed -${E} "s,Yes,${SED_RED_YELLOW},"
     print_list "core_pattern breakout .......... $core_pattern_breakout\n" | sed -${E} "s,Yes,${SED_RED_YELLOW},"


### PR DESCRIPTION
Looks like there's a typo in the label of the "run unshare" check.

The actual command that's run in the check is:

```
run_unshare=$(unshare -UrmC bash -c 'echo -n Yes' 2>/dev/null)
```

https://github.com/carlospolop/PEASS-ng/blob/20240114-925b57c0/linPEAS/builder/linpeas_parts/2_container.sh#L162
