### PR TITLE
Fix ANSI escape codes displaying as literal text in winPEAS.bat

### DIFF
--- a/winPEAS/winPEASbat/winPEAS.bat
+++ b/winPEAS/winPEASbat/winPEAS.bat
@@ -707,7 +707,8 @@ EXIT /B
 
 :SetOnce
 REM :: ANSI escape character is set once below - for ColorLine Subroutine
-SET "E=0x1B["
+for /F %%a in ('echo prompt $E ^| cmd') do set "ESC=%%a"
+SET "E=%ESC%["
 SET "PercentageTrack=0"
 EXIT /B
 


### PR DESCRIPTION
The script was setting E=0x1B[ as a literal string instead of the actual ESC character (ASCII 27), causing color codes to display as text like "0x1B[33m[+]0x1B[97m" instead of rendering as colors.

Changed the SetOnce subroutine to properly capture the ESC character using the 'prompt $E' technique before building the ANSI escape sequence prefix.

HERE ARE YOUR COLORS!! (win10/11) tested. 