### PR TITLE
Fix `su` bruteforce false positives on BusyBox systems (bbsuid)

### DIFF
--- a/linPEAS/builder/linpeas_parts/functions/su_try_pwd.sh
+++ b/linPEAS/builder/linpeas_parts/functions/su_try_pwd.sh
@@ -1,7 +1,7 @@
 # Title: LinPeasBase - su_try_pwd
 # ID: su_try_pwd
 # Author: Carlos Polop
-# Last Update: 22-08-2023
+# Last Update: 15-12-2025
 # Description: Try to login as user using a password
 # License: GNU GPL
 # Version: 1.0
@@ -17,7 +17,7 @@ su_try_pwd(){
   BFUSER=$1
   PASSWORDTRY=$2
   trysu=$(echo "$PASSWORDTRY" | timeout 1 su $BFUSER -c whoami 2>/dev/null)
-  if [ "$trysu" ]; then
+    if [ $? -eq 0 ]; then
     echo "  You can login as $BFUSER using password: $PASSWORDTRY" | sed -${E} "s,.*,${SED_RED_YELLOW},"
   fi
 }


### PR DESCRIPTION
Hi team,
I encountered a false positive issue with the su bruteforce function (su_try_pwd) while testing on a machine running Alpine Linux with BusyBox's su implementation (bbsuid).
<img width="1454" height="758" alt="7" src="https://github.com/user-attachments/assets/b315fbed-57c5-48d8-9223-d8709c5829d3" />

The Issue:
The current logic checks if [ "$trysu" ]; then. Since trysu captures stdout, and BusyBox's su outputs prompts (e.g., "Password:") and error messages to stdout instead of stderr when running non-interactively, the variable is never empty. This causes LinPEAS to report every password as valid.

Reproduction:
I verified this behavior on the target machine:
```bash
# Even with stderr discarded (2>/dev/null), stdout is NOT empty upon failure
$ su root 2>/dev/null
Password:
```
<img width="777" height="289" alt="10" src="https://github.com/user-attachments/assets/8cf7ac39-13e2-4d47-9b0b-1c29e4c79f76" />

The Fix:
I verified on the target system that despite the stdout behavior, BusyBox correctly returns a non-zero exit code on failure and 0 on success.

I have updated linPEAS/builder/linpeas_parts/functions/su_try_pwd.sh to rely on the exit code ($?) instead of the stdout content:
```bash
# Old
trysu=$(echo "$PASSWORDTRY" | timeout 1 su $BFUSER -c whoami 2>/dev/null)
if [ "$trysu" ]; then

# New
trysu=$(echo "$PASSWORDTRY" | timeout 1 su $BFUSER -c whoami 2>/dev/null)
if [ $? -eq 0 ]; then
```
I have tested this change locally on the affected machine, and it successfully eliminated the false positives while correctly identifying the valid password.

<img width="1386" height="299" alt="11" src="https://github.com/user-attachments/assets/f7bb8af8-f9ce-4798-9ff9-1bbb53daa6f3" />


Thanks for the great tool!


