### PR TITLE
fix: Highlight stored credentials in RDCMan.settings

### DIFF
--- a/build_lists/sensitive_files.yaml
+++ b/build_lists/sensitive_files.yaml
@@ -3546,7 +3546,7 @@ search:
 
           - name: "RDCMan.settings"
             value:
-                just_list_file: True
+                bad_regex: "credentialsProfiles|password|encryptedPassword"
                 type: f
                 search_in:
                   - common


### PR DESCRIPTION
Fixes https://github.com/peass-ng/PEASS-ng/issues/485
RDCMan.settings files can contain encrypted credentials in credentialsProfiles sections. This change enables content inspection to highlight:

- credentialsProfiles (indicates stored credentials)
- password (encrypted password value)
- encryptedPassword (alternative password field)

Previously, just_list_file only showed the file path without inspecting contents, causing stored credentials to be missed.