### PR TITLE
autoimprover: simplify linpeas checks

### DIFF
--- a/linPEAS/builder/linpeas_parts/3_cloud/10_Azure_automation_account.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud/10_Azure_automation_account.sh
@@ -5,7 +5,7 @@
 # Description: Azure Automation Account Service Enumeration
 # License: GNU GPL
 # Version: 1.0
-# Functions Used: check_az_automation_acc, exec_with_jq, print_2title, print_3title
+# Functions Used: check_az_automation_acc, exec_with_jq, print_2title, print_3title, set_metadata_req_cmd
 # Global Variables: $is_az_automation_acc,
 # Initial Functions: check_az_automation_acc
 # Generated Global Variables: $API_VERSION, $HEADER, $az_req
@@ -21,13 +21,7 @@ if [ "$is_az_automation_acc" = "Yes" ]; then
   HEADER="X-IDENTITY-HEADER:$IDENTITY_HEADER"
 
   az_req=""
-  if [ "$(command -v curl || echo -n '')" ]; then
-      az_req="curl -s -f -L -H '$HEADER'"
-  elif [ "$(command -v wget || echo -n '')" ]; then
-      az_req="wget -q -O - --header '$HEADER'"
-  else 
-      echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
-  fi
+  set_metadata_req_cmd az_req "$HEADER"
 
   if [ "$az_req" ]; then
     print_3title "Management token"

--- a/linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh
@@ -5,7 +5,7 @@
 # Description: Azure VM Enumeration
 # License: GNU GPL
 # Version: 1.0
-# Functions Used: check_az_vm, exec_with_jq, print_2title, print_3title
+# Functions Used: check_az_vm, exec_with_jq, print_2title, print_3title, set_metadata_req_cmd
 # Global Variables: $is_az_vm
 # Initial Functions: check_az_vm
 # Generated Global Variables: $API_VERSION, $HEADER, $az_req, $URL
@@ -21,13 +21,7 @@ if [ "$is_az_vm" = "Yes" ]; then
   API_VERSION="2021-12-13" #https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#supported-api-versions
   
   az_req=""
-  if [ "$(command -v curl || echo -n '')" ]; then
-      az_req="curl -s -f -L -H '$HEADER'"
-  elif [ "$(command -v wget || echo -n '')" ]; then
-      az_req="wget -q -O - --header '$HEADER'"
-  else 
-      echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
-  fi
+  set_metadata_req_cmd az_req "$HEADER"
 
   if [ "$az_req" ]; then
     print_3title "Instance details"

--- a/linPEAS/builder/linpeas_parts/3_cloud/9_Azure_app_service.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud/9_Azure_app_service.sh
@@ -5,7 +5,7 @@
 # Description: Azure App Service Enumeration
 # License: GNU GPL
 # Version: 1.0
-# Functions Used: check_az_app, exec_with_jq, print_2title, print_3title
+# Functions Used: check_az_app, exec_with_jq, print_2title, print_3title, set_metadata_req_cmd
 # Global Variables: $is_az_app,
 # Initial Functions: check_az_app
 # Generated Global Variables: $API_VERSION, $HEADER, $az_req
@@ -21,13 +21,7 @@ if [ "$is_az_app" = "Yes" ]; then
   HEADER="X-IDENTITY-HEADER:$IDENTITY_HEADER"
 
   az_req=""
-  if [ "$(command -v curl || echo -n '')" ]; then
-      az_req="curl -s -f -L -H '$HEADER'"
-  elif [ "$(command -v wget || echo -n '')" ]; then
-      az_req="wget -q -O - --header '$HEADER'"
-  else 
-      echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
-  fi
+  set_metadata_req_cmd az_req "$HEADER"
 
   if [ "$az_req" ]; then
     print_3title "Management token"

--- a/linPEAS/builder/linpeas_parts/functions/set_metadata_req_cmd.sh
+++ b/linPEAS/builder/linpeas_parts/functions/set_metadata_req_cmd.sh
@@ -1,0 +1,29 @@
+# Title: Cloud - set_metadata_req_cmd
+# ID: set_metadata_req_cmd
+# Author: Carlos Polop
+# Last Update: 22-08-2023
+# Description: Set a metadata service request command based on curl/wget availability
+# License: GNU GPL
+# Version: 1.0
+# Functions Used:
+# Global Variables:
+# Initial Functions:
+# Generated Global Variables:
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+set_metadata_req_cmd(){
+  local req_var="$1"
+  local header="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    printf -v "$req_var" "curl -s -f -L -H '%s'" "$header"
+  elif command -v wget >/dev/null 2>&1; then
+    printf -v "$req_var" "wget -q -O - --header '%s'" "$header"
+  else
+    echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
+    printf -v "$req_var" ""
+    return 1
+  fi
+}


### PR DESCRIPTION
Automated simplifications for linpeas checks.\n\nAgent summary:\nPEASS linpeas autoimprover agent completed successfully with 71 items. Agent Comment: Summary:
- Added shared `set_metadata_req_cmd` helper function to centralize curl/wget selection for Azure metadata requests.
- Updated Azure VM, Azure App Service, and Azure Automation Account modules to use the shared helper, removing duplicated command-selection blocks.

Tests: Not run (not requested).\n\nGenerated by PEASS autoimprover workflow.