### PR TITLE
autoimprover: simplify winpeas checks

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/ProcessInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ProcessInfo.cs
@@ -56,10 +56,9 @@ namespace winPEAS.Checks
                         colorsP[procInfo["Product"]] = Beaprint.ansi_color_bad;
                     }
 
-                    List<string> fileRights = PermissionsHelper.GetPermissionsFile(procInfo["ExecutablePath"], Checks.CurrentUserSiDs);
-                    List<string> dirRights = new List<string>();
-                    if (procInfo["ExecutablePath"] != null && procInfo["ExecutablePath"] != "")
-                        dirRights = PermissionsHelper.GetPermissionsFolder(Path.GetDirectoryName(procInfo["ExecutablePath"]), Checks.CurrentUserSiDs);
+                    List<string> fileRights;
+                    List<string> dirRights;
+                    PermissionsHelper.GetFileAndDirectoryPermissions(procInfo["ExecutablePath"], Checks.CurrentUserSiDs, out fileRights, out dirRights);
 
                     colorsP[procInfo["ExecutablePath"].Replace("\\", "\\\\").Replace("(", "\\(").Replace(")", "\\)").Replace("]", "\\]").Replace("[", "\\[").Replace("?", "\\?").Replace("+", "\\+") + "[^\"^']"] = (fileRights.Count > 0 || dirRights.Count > 0) ? Beaprint.ansi_color_bad : Beaprint.ansi_color_good;
 

--- a/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
@@ -58,13 +58,9 @@ namespace winPEAS.Checks
 
                 foreach (Dictionary<string, string> serviceInfo in services_info)
                 {
-                    List<string> fileRights = PermissionsHelper.GetPermissionsFile(serviceInfo["FilteredPath"], Checks.CurrentUserSiDs);
-                    List<string> dirRights = new List<string>();
-
-                    if (serviceInfo["FilteredPath"] != null && serviceInfo["FilteredPath"] != "")
-                    {
-                        dirRights = PermissionsHelper.GetPermissionsFolder(Path.GetDirectoryName(serviceInfo["FilteredPath"]), Checks.CurrentUserSiDs);
-                    }
+                    List<string> fileRights;
+                    List<string> dirRights;
+                    PermissionsHelper.GetFileAndDirectoryPermissions(serviceInfo["FilteredPath"], Checks.CurrentUserSiDs, out fileRights, out dirRights);
 
                     bool noQuotesAndSpace = MyUtils.CheckQuoteAndSpace(serviceInfo["PathName"]);
 

--- a/winPEAS/winPEASexe/winPEAS/Helpers/PermissionsHelper.cs
+++ b/winPEAS/winPEASexe/winPEAS/Helpers/PermissionsHelper.cs
@@ -84,6 +84,21 @@ namespace winPEAS.Helpers
             return results;
         }
 
+        public static void GetFileAndDirectoryPermissions(string path, Dictionary<string, string> SIDs, out List<string> fileRights, out List<string> dirRights, PermissionType permissionType = PermissionType.DEFAULT)
+        {
+            fileRights = GetPermissionsFile(path, SIDs, permissionType);
+            dirRights = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                string directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrWhiteSpace(directory))
+                {
+                    dirRights = GetPermissionsFolder(directory, SIDs, permissionType);
+                }
+            }
+        }
+
         public static List<string> GetMyPermissionsF(FileSecurity fSecurity, Dictionary<string, string> SIDs, PermissionType permissionType = PermissionType.DEFAULT)
         {
             // Get interesting permissions in fSecurity (Only files and folders)


### PR DESCRIPTION
Automated simplifications for winpeas checks.\n\nAgent summary:\nPEASS winpeas autoimprover agent completed successfully with 82 items. Agent Comment: Summary:
- Added `PermissionsHelper.GetFileAndDirectoryPermissions` to centralize the common file + parent directory permission lookup logic.
- Updated `ServicesInfo.PrintInterestingServices` and `ProcessInfo.PrintInterestingProcesses` to use the new helper, reducing duplicated permission-fetching code without changing output formatting.

Tests:
- Not run (no automated tests requested).\n\nGenerated by PEASS autoimprover workflow.