### PR TITLE
Avoid CVE-2021-3560 false positives on Ubuntu

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information/15_CVE_2021_3560.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information/15_CVE_2021_3560.sh
@@ -30,10 +30,9 @@
 # Fat linpeas: 0
 # Small linpeas: 0
 
-if apt list --installed 2>/dev/null | grep -q 'polkit.*0\.105-26' || \
+if apt list --installed 2>/dev/null | grep -E 'polkit.*0\.105-26' | grep -qEv 'ubuntu1\.[1-9]' || \
    yum list installed 2>/dev/null | grep -q 'polkit.*\(0\.117-2\|0\.115-6\)' || \
    rpm -qa 2>/dev/null | grep -q 'polkit.*\(0\.117-2\|0\.115-6\)'; then
     echo "Vulnerable to CVE-2021-3560" | sed -${E} "s,.*,${SED_RED_YELLOW},"
     echo ""
 fi
-


### PR DESCRIPTION
Fixes #463.