### PR TITLE
Guard infos handling in peas2json parser

### DIFF
--- a/parsers/peas2json.py
+++ b/parsers/peas2json.py
@@ -127,7 +127,9 @@ def parse_line(line: str):
 
     elif is_section(line, INFO_PATTERN):
         title = parse_title(line)
-        C_SECTION["infos"].append(title)
+        if C_SECTION == {}:
+            return
+        C_SECTION.setdefault("infos", []).append(title)
     
     #If here, then it's text
     else:


### PR DESCRIPTION
Fix parser crash when winPEAS logs omit info sections.