### PR TITLE
Fix Browser_profiles module ID casing

### DIFF
--- a/linPEAS/builder/linpeas_parts/7_software_information/Browser_profiles.sh
+++ b/linPEAS/builder/linpeas_parts/7_software_information/Browser_profiles.sh
@@ -1,5 +1,5 @@
 # Title: Software Information - Browser Profiles
-# ID: SW_Browser_Profiles
+# ID: SW_Browser_profiles
 # Author: Carlos Polop
 # Last Update: 10-03-2025
 # Description: List browser profiles that may store credentials/cookies


### PR DESCRIPTION
Fixes CI-master_test failure caused by module ID mismatch in Browser_profiles.sh.