### PR TITLE
autoimprover: simplify winpeas checks

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/FilesInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/FilesInfo.cs
@@ -524,7 +524,7 @@ namespace winPEAS.Checks
             {
                 Beaprint.MainPrint("Looking for documents --limit 100--");
                 List<string> docFiles = InterestingFiles.InterestingFiles.ListUsersDocs();
-                Beaprint.ListPrint(docFiles.GetRange(0, docFiles.Count <= 100 ? docFiles.Count : 100));
+                Beaprint.ListPrint(MyUtils.GetLimitedRange(docFiles, 100));
             }
             catch (Exception ex)
             {
@@ -546,7 +546,7 @@ namespace winPEAS.Checks
 
                 if (recFiles.Count != 0)
                 {
-                    foreach (Dictionary<string, string> recF in recFiles.GetRange(0, recFiles.Count <= 70 ? recFiles.Count : 70))
+                    foreach (Dictionary<string, string> recF in MyUtils.GetLimitedRange(recFiles, 70))
                     {
                         Beaprint.AnsiPrint("    " + recF["Target"] + "(" + recF["Accessed"] + ")", colorF);
                     }

--- a/winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs
@@ -348,8 +348,7 @@ namespace winPEAS.Checks
                 Beaprint.MainPrint("DNS cached --limit 70--");
                 Beaprint.GrayPrint(string.Format("    {0,-38}{1,-38}{2}", "Entry", "Name", "Data"));
                 List<Dictionary<string, string>> DNScache = NetworkInfoHelper.GetDNSCache();
-                foreach (Dictionary<string, string> entry in DNScache.GetRange(0,
-                    DNScache.Count <= 70 ? DNScache.Count : 70))
+                foreach (Dictionary<string, string> entry in MyUtils.GetLimitedRange(DNScache, 70))
                 {
                     Console.WriteLine($"    {entry["Entry"],-38}{entry["Name"],-38}{entry["Data"]}");
                 }

--- a/winPEAS/winPEASexe/winPEAS/Helpers/MyUtils.cs
+++ b/winPEAS/winPEASexe/winPEAS/Helpers/MyUtils.cs
@@ -21,6 +21,11 @@ namespace winPEAS.Helpers
                 ""); //To get the default object you need to use an empty string
         }
 
+        public static List<T> GetLimitedRange<T>(List<T> items, int limit)
+        {
+            return items.GetRange(0, Math.Min(items.Count, limit));
+        }
+
         ////////////////////////////////////
         /////// MISC - Files & Paths ///////
         ////////////////////////////////////


### PR DESCRIPTION
Automated simplifications for winpeas checks.\n\nAgent summary:\nPEASS winpeas autoimprover agent completed successfully with 76 items. Agent Comment: Summary:
- Added `MyUtils.GetLimitedRange` helper to centralize list limiting logic.
- Updated `FilesInfo.PrintUsersDocsKeys`, `FilesInfo.PrintRecentFiles`, and `NetworkInfo.PrintDNSCache` to use the shared helper instead of repeating range calculations.

Tests: Not run (not requested).\n\nGenerated by PEASS autoimprover workflow.