### PR TITLE
autoimprover: simplify linpeas checks

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information/16_Protections.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information/16_Protections.sh
@@ -30,7 +30,7 @@
 # Functions Used: echo_not_found, print_2title, print_list, warn_exec
 # Global Variables:
 # Initial Functions:
-# Generated Global Variables: $ASLR, $hypervisorflag, $detectedvirt, $unpriv_userns_clone, $perf_event_paranoid, $mmap_min_addr, $ptrace_scope, $dmesg_restrict, $kptr_restrict, $unpriv_bpf_disabled, $protected_symlinks, $protected_hardlinks
+# Generated Global Variables: $ASLR, $hypervisorflag, $detectedvirt, $unpriv_userns_clone, $perf_event_paranoid, $mmap_min_addr, $ptrace_scope, $dmesg_restrict, $kptr_restrict, $unpriv_bpf_disabled, $protected_symlinks, $protected_hardlinks, $label, $sysctl_path, $sysctl_var, $zero_color, $nonzero_color, $sysctl_value
 # Fat linpeas: 0
 # Small linpeas: 0
 


### PR DESCRIPTION
Automated simplifications for linpeas checks.\n\nAgent summary:\nPEASS linpeas autoimprover agent completed successfully with 103 items. Agent Comment: Summary:
- Added a local `print_sysctl_eq_zero` helper in `linPEAS/builder/linpeas_parts/1_system_information/16_Protections.sh` to consolidate repeated sysctl checks while preserving existing output/behavior and still setting the same global variables.
- Replaced the duplicated per-sysctl blocks (unprivileged userns/eBPF, kptr/dmesg/ptrace, protected links, mmap_min_addr) with the helper for cleaner, more maintainable logic.

Tests:
- `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh` **failed**: `ModuleNotFoundError: No module named 'builder'`.\n\nGenerated by PEASS autoimprover workflow.