### PR TITLE
Fix linPEAS Systemd module metadata for builder CI

### DIFF
--- a/linPEAS/builder/linpeas_parts/4_procs_crons_timers_srvcs_sockets/11_Systemd.sh
+++ b/linPEAS/builder/linpeas_parts/4_procs_crons_timers_srvcs_sockets/11_Systemd.sh
@@ -17,7 +17,7 @@
 # Functions Used: print_2title, print_list, echo_not_found
 # Global Variables: $SEARCH_IN_FOLDER, $Wfolders, $SED_RED, $SED_RED_YELLOW, $NC
 # Initial Functions:
-# Generated Global Variables: $WRITABLESYSTEMDPATH, $line, $service, $file, $version, $user, $caps, $path, $path_line, $service_file, $exec_line, $cmd
+# Generated Global Variables: $WRITABLESYSTEMDPATH, $line, $service, $file, $version, $user, $caps, $path, $path_line, $service_file, $exec_line, $exec_value, $cmd, $cmd_path
 # Fat linpeas: 0
 # Small linpeas: 1
 


### PR DESCRIPTION
## What
The CI run https://github.com/peass-ng/PEASS-ng/actions/runs/21640729178 failed in linpeas/macpeas builds because `11_Systemd.sh` uses `$exec_value` and `$cmd_path` but they were missing from the module metadata list (`Generated Global Variables`).

This patch adds both variables to the metadata declaration.

## Validation
- Ran: `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh`
- Result: builder completed successfully (including syntax checks and final sanity checks).
