### PR TITLE
Test Chack Agent PR+master failure workflows

### DIFF
--- a/CHACK_AGENT_TESTING_NOTES.md
+++ b/CHACK_AGENT_TESTING_NOTES.md
@@ -1,0 +1,10 @@
+# Chack Agent Testing Notes
+
+This branch is intentionally prepared to validate automated CI-fix workflows.
+
+## Why this exists
+- Provide a simple and explicit branch-level note for maintainers.
+- Exercise failure-triggered automation in a controlled way.
+
+## Cleanup reminder
+After workflow validation is complete, revert the intentional CI break commit.

--- a/linPEAS/builder/linpeas_builder.py
+++ b/linPEAS/builder/linpeas_builder.py
@@ -7,6 +7,9 @@ import os
 import stat
 import argparse
 
+# Intentional break for CI automation workflow validation.
+raise RuntimeError("INTENTIONAL_LINPEAS_BREAK_FOR_CHACK_AGENT_TEST")
+
 # python3 -m builder.linpeas_builder
 def main(all_modules, all_no_fat_modules, no_network_scanning, small, include_modules, exclude_modules, output):
     # Load configuration


### PR DESCRIPTION
This PR is intentionally crafted to validate Chack Agent automation:

- Adds a small maintainer note file (`CHACK_AGENT_TESTING_NOTES.md`) as a harmless change.
- Introduces an intentional linpeas runtime break to force CI failure and trigger automated fixer workflows.

Expected test behavior:
- `PR-tests` fails on this PR.
- `PR Failure Chack-Agent Dispatch` runs and attempts a fix.
- If merged to master (or equivalent controlled master failure test), `CI-master Failure Chack-Agent PR` should run and attempt branch+PR fix flow.

After testing, the intentional break should be reverted.
