### PR TITLE
Enable Chack workflow_run automation with Codex backend

### DIFF
--- a/.github/workflows/chack-agent-pr-triage.yml
+++ b/.github/workflows/chack-agent-pr-triage.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   chack_agent_triage:
-    # Temporarily disabled by maintainer request.
-    if: ${{ false && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -83,12 +82,24 @@ jobs:
             ${{ steps.gate.outputs.base_ref }} \
             +refs/pull/${{ steps.gate.outputs.pr_number }}/head
 
+      - name: Set up Node.js for Codex
+        if: ${{ steps.gate.outputs.should_run == 'true' }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install Codex CLI
+        if: ${{ steps.gate.outputs.should_run == 'true' }}
+        run: |
+          npm install -g @openai/codex
+          codex --version
+
       - name: Run Chack Agent
         id: run_chack
         if: ${{ steps.gate.outputs.should_run == 'true' }}
         uses: carlospolop/chack-agent@master
         with:
-          provider: openrouter
+          provider: codex
           model_primary: CHEAP_BUT_QUALITY
           main_action: peass-ng
           sub_action: Chack-Agent PR Triage
@@ -123,7 +134,7 @@ jobs:
 
             Output JSON only, following the provided schema:
             .github/chack-agent/pr-merge-schema.json
-          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Parse Chack Agent decision
         id: parse
@@ -157,8 +168,7 @@ jobs:
   merge_or_comment:
     runs-on: ubuntu-latest
     needs: chack_agent_triage
-    # Temporarily disabled by maintainer request.
-    if: ${{ false && github.event.workflow_run.conclusion == 'success' && needs.chack_agent_triage.outputs.should_run == 'true' && needs.chack_agent_triage.outputs.decision != '' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.chack_agent_triage.outputs.should_run == 'true' && needs.chack_agent_triage.outputs.decision != '' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci-master-failure-chack-agent-pr.yml
+++ b/.github/workflows/ci-master-failure-chack-agent-pr.yml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   chack_agent_fix_master_failure:
-    # Temporarily disabled by maintainer request.
     if: >
-      ${{ false && github.event.workflow_run.conclusion == 'failure' &&
+      ${{ github.event.workflow_run.conclusion == 'failure' &&
           github.event.workflow_run.head_branch == 'master' &&
           !startsWith(github.event.workflow_run.head_commit.message, 'Fix CI-master failures for run #') }}
     runs-on: ubuntu-latest
@@ -98,11 +97,21 @@ jobs:
             echo "Leave the repo in a state ready to commit; changes will be committed and pushed automatically."
           } > chack_prompt.txt
 
+      - name: Set up Node.js for Codex
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install Codex CLI
+        run: |
+          npm install -g @openai/codex
+          codex --version
+
       - name: Run Chack Agent
         id: run_chack
         uses: carlospolop/chack-agent@master
         with:
-          provider: openrouter
+          provider: codex
           model_primary: CHEAP_BUT_QUALITY
           main_action: peass-ng
           sub_action: CI-master Failure Chack-Agent PR
@@ -113,7 +122,7 @@ jobs:
           tools_config_json: "{\"exec_enabled\": true}"
           session_config_json: "{\"long_term_memory_enabled\": false}"
           agent_config_json: "{\"self_critique_enabled\": false, \"require_task_list_init_first\": true}"
-          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Commit and push fix branch if changed
         id: push_fix

--- a/.github/workflows/pr-failure-chack-agent-dispatch.yml
+++ b/.github/workflows/pr-failure-chack-agent-dispatch.yml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   resolve_pr_context:
-    # Temporarily disabled by maintainer request.
     if: >
-      ${{ false && github.event.workflow_run.conclusion == 'failure' &&
+      ${{ github.event.workflow_run.conclusion == 'failure' &&
           github.event.workflow_run.pull_requests &&
           github.event.workflow_run.pull_requests[0] &&
           !startsWith(github.event.workflow_run.head_commit.message, 'Fix CI failures for PR #') }}
@@ -58,8 +57,7 @@ jobs:
 
   chack_agent_on_failure:
     needs: resolve_pr_context
-    # Temporarily disabled by maintainer request.
-    if: ${{ false && needs.resolve_pr_context.outputs.author == 'carlospolop' && needs.resolve_pr_context.outputs.should_run == 'true' }}
+    if: ${{ needs.resolve_pr_context.outputs.author == 'carlospolop' && needs.resolve_pr_context.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -156,11 +154,21 @@ jobs:
             echo "Leave the repo in a state ready to commit as when you finish, it'll be automatically committed and pushed."
           } > chack_prompt.txt
 
+      - name: Set up Node.js for Codex
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install Codex CLI
+        run: |
+          npm install -g @openai/codex
+          codex --version
+
       - name: Run Chack Agent
         id: run_chack
         uses: carlospolop/chack-agent@master
         with:
-          provider: openrouter
+          provider: codex
           model_primary: CHEAP_BUT_QUALITY
           main_action: peass-ng
           sub_action: PR Failure Chack-Agent Dispatch
@@ -172,7 +180,7 @@ jobs:
           tools_config_json: "{\"exec_enabled\": true}"
           session_config_json: "{\"long_term_memory_enabled\": false}"
           agent_config_json: "{\"self_critique_enabled\": false, \"require_task_list_init_first\": true}"
-          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Commit and push if changed
         env:


### PR DESCRIPTION
Enables the Chack workflow_run jobs currently disabled by  guards and switches repo workflows to the Codex provider with Codex CLI installation + OPENAI_API_KEY wiring.\n\nThis is required so PR-test failures can trigger Chack auto-fix, and successful PR-tests can trigger Chack triage/merge-comment.