### PR TITLE
Fix Chack workflow agent_config key

### DIFF
--- a/.github/workflows/chack-agent-pr-triage.yml
+++ b/.github/workflows/chack-agent-pr-triage.yml
@@ -110,7 +110,7 @@ jobs:
             Remember taht you are an autonomouts agent, use the exec tool to run the needed commands to list, read, analyze, modify, test...
           tools_config_json: "{\"exec_enabled\": true}"
           session_config_json: "{\"long_term_memory_enabled\": false}"
-          agent_config_json: "{\"self_critique_enabled\": false, \"require_task_list_init_first\": true}"
+          agent_config_json: "{\"self_critique_enabled\": false, \"require_task_steps_manager_init_first\": true}"
           output_schema_file: .github/chack-agent/pr-merge-schema.json
           user_prompt: |
             You are reviewing PR #${{ steps.gate.outputs.pr_number }} for ${{ github.repository }}.

--- a/.github/workflows/ci-master-failure-chack-agent-pr.yml
+++ b/.github/workflows/ci-master-failure-chack-agent-pr.yml
@@ -121,7 +121,7 @@ jobs:
           prompt_file: chack_prompt.txt
           tools_config_json: "{\"exec_enabled\": true}"
           session_config_json: "{\"long_term_memory_enabled\": false}"
-          agent_config_json: "{\"self_critique_enabled\": false, \"require_task_list_init_first\": true}"
+          agent_config_json: "{\"self_critique_enabled\": false, \"require_task_steps_manager_init_first\": true}"
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Commit and push fix branch if changed

--- a/.github/workflows/pr-failure-chack-agent-dispatch.yml
+++ b/.github/workflows/pr-failure-chack-agent-dispatch.yml
@@ -179,7 +179,7 @@ jobs:
           prompt_file: chack_prompt.txt
           tools_config_json: "{\"exec_enabled\": true}"
           session_config_json: "{\"long_term_memory_enabled\": false}"
-          agent_config_json: "{\"self_critique_enabled\": false, \"require_task_list_init_first\": true}"
+          agent_config_json: "{\"self_critique_enabled\": false, \"require_task_steps_manager_init_first\": true}"
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Commit and push if changed


### PR DESCRIPTION
Fixes a runtime failure in Chack GitHub workflows by replacing  with the valid  key.