### PR TITLE
Fix macOS CI pip installs for PEASS workflows

### DIFF
--- a/.github/workflows/CI-master_tests.yml
+++ b/.github/workflows/CI-master_tests.yml
@@ -371,8 +371,8 @@ jobs:
       # Build linpeas
       - name: Build macpeas
         run: |
-          python3 -m pip install PyYAML --break-system-packages
-          python3 -m pip install requests --break-system-packages
+          python3 -m pip install PyYAML
+          python3 -m pip install requests
           cd linPEAS
           python3 -m builder.linpeas_builder --all --output linpeas_fat.sh
       

--- a/.github/workflows/PR-tests.yml
+++ b/.github/workflows/PR-tests.yml
@@ -178,8 +178,8 @@ jobs:
       # Build linpeas (macpeas)
       - name: Build macpeas
         run: |
-          python3 -m pip install PyYAML --break-system-packages
-          python3 -m pip install requests --break-system-packages
+          python3 -m pip install PyYAML
+          python3 -m pip install requests
           cd linPEAS
           python3 -m builder.linpeas_builder --all --output linpeas_fat.sh
       


### PR DESCRIPTION
Removes  from macOS pip install steps in PR-tests and CI-master_test workflows to avoid false failures and keep CI portable.