### PR TITLE
Harden Chack PR failure->retest->triage workflow chain

### DIFF
--- a/.github/workflows/CI-master_tests.yml
+++ b/.github/workflows/CI-master_tests.yml
@@ -371,8 +371,8 @@ jobs:
       # Build linpeas
       - name: Build macpeas
         run: |
-          python3 -m pip install PyYAML
-          python3 -m pip install requests
+          python3 -m pip install PyYAML --break-system-packages
+          python3 -m pip install requests --break-system-packages
           cd linPEAS
           python3 -m builder.linpeas_builder --all --output linpeas_fat.sh
       

--- a/.github/workflows/PR-tests.yml
+++ b/.github/workflows/PR-tests.yml
@@ -178,8 +178,8 @@ jobs:
       # Build linpeas (macpeas)
       - name: Build macpeas
         run: |
-          python3 -m pip install PyYAML
-          python3 -m pip install requests
+          python3 -m pip install PyYAML --break-system-packages
+          python3 -m pip install requests --break-system-packages
           cd linPEAS
           python3 -m builder.linpeas_builder --all --output linpeas_fat.sh
       

--- a/.github/workflows/chack-agent-pr-triage.yml
+++ b/.github/workflows/chack-agent-pr-triage.yml
@@ -30,10 +30,15 @@ jobs:
       - name: Resolve PR context
         id: gate
         env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          pr_number="${{ github.event.workflow_run.pull_requests[0].number }}"
+          pr_number="${PR_NUMBER}"
+          if [ -z "$pr_number" ] && [ -n "$HEAD_BRANCH" ]; then
+            pr_number="$(gh pr list --state open --head "$HEAD_BRANCH" --json number --jq '.[0].number')"
+          fi
           if [ -z "$pr_number" ]; then
             echo "No pull request found for this workflow_run; skipping."
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-failure-chack-agent-dispatch.yml
+++ b/.github/workflows/pr-failure-chack-agent-dispatch.yml
@@ -9,9 +9,7 @@ jobs:
   resolve_pr_context:
     if: >
       ${{ github.event.workflow_run.conclusion == 'failure' &&
-          github.event.workflow_run.pull_requests &&
-          github.event.workflow_run.pull_requests[0] &&
-          !startsWith(github.event.workflow_run.head_commit.message, 'Fix CI failures for PR #') }}
+          !startsWith(github.event.workflow_run.head_commit.message || '', 'Fix CI failures for PR #') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -27,8 +25,23 @@ jobs:
         id: pr_context
         env:
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [ -z "$PR_NUMBER" ] && [ -n "$HEAD_BRANCH" ]; then
+            PR_NUMBER="$(gh pr list --state open --head "$HEAD_BRANCH" --json number --jq '.[0].number')"
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No pull request found for workflow_run; skipping."
+            {
+              echo "number="
+              echo "author="
+              echo "head_repo="
+              echo "head_branch=${HEAD_BRANCH}"
+              echo "should_run=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           pr_author=$(gh api -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/pulls/${PR_NUMBER} \
             --jq '.user.login')
@@ -63,7 +76,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      actions: read
+      actions: write
     env:
       CHACK_LOGS_HTTP_URL: ${{ secrets.CHACK_LOGS_HTTP_URL }}
     steps:
@@ -186,6 +199,7 @@ jobs:
         env:
           TARGET_BRANCH: ${{ needs.resolve_pr_context.outputs.head_branch }}
           PR_NUMBER: ${{ needs.resolve_pr_context.outputs.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet; then
             echo "No changes to commit."
@@ -211,6 +225,7 @@ jobs:
             echo "Push failed (likely token workflow permission limits); leaving run successful without push."
             exit 0
           fi
+          gh workflow run PR-tests.yml --ref "${TARGET_BRANCH}"
 
       - name: Comment with Chack Agent result
         if: ${{ steps.run_chack.outputs.final-message != '' }}


### PR DESCRIPTION
- Restore macOS pip installs with --break-system-packages in PR/master test workflows\n- Add PR lookup fallback by head branch for workflow_run events without pull_requests\n- After Chack push, dispatch PR-tests on target branch so fixes are re-tested automatically