### PR TITLE
workflow: sanitize chack fixes to avoid workflow push rejection

### DIFF
--- a/.github/workflows/pr-failure-chack-agent-dispatch.yml
+++ b/.github/workflows/pr-failure-chack-agent-dispatch.yml
@@ -147,6 +147,51 @@ jobs:
           with open('chack_failure_summary.txt', 'w') as handle:
             handle.write(summary)
           PY
+          python3 - <<'PY'
+          import json
+          import subprocess
+          from pathlib import Path
+
+          jobs = json.load(open('/tmp/jobs.json')).get('jobs', [])
+          failed_jobs = [j for j in jobs if j.get('conclusion') == 'failure']
+          details = []
+
+          def keep_line(text: str) -> bool:
+            t = text.lower()
+            needles = (
+              "error",
+              "failed",
+              "traceback",
+              "exception",
+              "attributeerror",
+              "no such file",
+              "not found",
+            )
+            return any(n in t for n in needles)
+
+          run_id = "${{ github.event.workflow_run.id }}"
+          for job in failed_jobs:
+            job_id = str(job.get("id"))
+            job_name = str(job.get("name") or "")
+            details.append(f"===== Failed job log excerpt: {job_name} (id {job_id}) =====")
+            try:
+              proc = subprocess.run(
+                ["gh", "run", "view", run_id, "--job", job_id, "--log"],
+                check=False,
+                capture_output=True,
+                text=True,
+              )
+              log_text = proc.stdout or ""
+              lines = [ln for ln in log_text.splitlines() if keep_line(ln)]
+              tail = log_text.splitlines()[-120:]
+              excerpt = lines[-80:] if lines else tail
+              details.extend(excerpt)
+            except Exception as exc:
+              details.append(f"(failed to fetch logs for job {job_id}: {exc})")
+            details.append("")
+
+          Path("chack_failure_details.txt").write_text("\n".join(details).strip() + "\n")
+          PY
 
       - name: Create Chack Agent prompt
         env:
@@ -162,7 +207,14 @@ jobs:
             echo "Failure summary:"
             cat chack_failure_summary.txt
             echo ""
+            echo "Detailed failing log excerpts:"
+            cat chack_failure_details.txt
+            echo ""
             echo "Please identify the cause, apply a easy, simple and minimal fix, and update files accordingly."
+            echo "Important constraints:"
+            echo "- Do NOT modify any file under .github/workflows/."
+            echo "- Focus only on fixing code/scripts for this PR branch."
+            echo "- Verify with 'git status --short' and 'git diff --name-only' before finishing."
             echo "Run any fast checks you can locally (no network)."
             echo "Leave the repo in a state ready to commit as when you finish, it'll be automatically committed and pushed."
           } > chack_prompt.txt
@@ -202,7 +254,7 @@ jobs:
           ORIGINAL_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          rm -f chack_failure_summary.txt chack_prompt.txt
+          rm -f chack_failure_summary.txt chack_failure_details.txt chack_prompt.txt
 
           pushed=false
 
@@ -212,7 +264,7 @@ jobs:
             git reset -- .github/workflows || true
             git checkout -- .github/workflows || true
             git clean -fdx -- .github/workflows || true
-            git reset -- chack_failure_summary.txt chack_prompt.txt
+            git reset -- chack_failure_summary.txt chack_failure_details.txt chack_prompt.txt
             if git diff --cached --name-only | grep -q '^.github/workflows/'; then
               echo "Workflow-file changes are still staged; skipping push without workflows permission."
               exit 0
@@ -226,6 +278,23 @@ jobs:
           if [ "$after_head" = "$ORIGINAL_HEAD_SHA" ]; then
             echo "No commit produced by Chack Agent for PR #${PR_NUMBER}."
             exit 0
+          fi
+
+          changed_in_range="$(git diff --name-only "$ORIGINAL_HEAD_SHA"..HEAD)"
+          if echo "$changed_in_range" | grep -q '^.github/workflows/'; then
+            echo "Detected workflow changes in Chack commit range; sanitizing commit before push."
+            git diff --binary "$ORIGINAL_HEAD_SHA"..HEAD -- . ':(exclude).github/workflows/**' > /tmp/chack_nonworkflow.patch
+            if [ ! -s /tmp/chack_nonworkflow.patch ]; then
+              echo "Only workflow-file changes were produced; skipping push."
+              exit 0
+            fi
+            git reset --hard "$ORIGINAL_HEAD_SHA"
+            git apply --index /tmp/chack_nonworkflow.patch
+            if git diff --cached --quiet; then
+              echo "No non-workflow changes left after sanitizing."
+              exit 0
+            fi
+            git commit -m "Fix CI failures for PR #${PR_NUMBER}"
           fi
 
           if ! git push origin HEAD:${TARGET_BRANCH}; then


### PR DESCRIPTION
## Summary
- add failed-job log excerpts into Chack prompt context
- instruct Chack not to touch `.github/workflows/`
- sanitize generated commit range by stripping workflow-file changes before push

## Why
PR #594 showed Chack making workflow edits that cannot be pushed with the current token permissions. This makes the fix flow appear successful while no commit reaches the PR branch.

This change keeps the auto-fix flow robust even when Chack touches restricted files.