### PR TITLE
autoimprover: simplify winpeas checks

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs
@@ -141,63 +141,33 @@ namespace winPEAS.Checks
             Beaprint.MainPrint("Current TCP Listening Ports");
             Beaprint.LinkPrint("", "Check for services restricted from the outside");
 
-            PrintListeningPortsTcpIPv4(processesByPid);
+            PrintListeningPortsTcpByVersion(processesByPid, IPVersion.IPv4,
+                @"{0,-12} {1,-21} {2,-13} {3,-21} {4,-15} {5,-17} {6,-15} {7}",
+                address => address.ToString());
             Beaprint.ColorPrint("", Beaprint.NOCOLOR);
-            PrintListeningPortsTcpIPv6(processesByPid);
+            PrintListeningPortsTcpByVersion(processesByPid, IPVersion.IPv6,
+                @"{0,-12} {1,-43} {2,-13} {3,-43} {4,-15} {5,-17} {6,-15} {7}",
+                address => $"[{address}]");
         }
 
-        private void PrintListeningPortsTcpIPv4(Dictionary<int, Process> processesByPid)
+        private void PrintListeningPortsTcpByVersion(Dictionary<int, Process> processesByPid, IPVersion ipVersion, string formatString, Func<System.Net.IPAddress, string> addressFormatter)
         {
             try
             {
-                Beaprint.ColorPrint("  Enumerating IPv4 connections\n", Beaprint.LBLUE);
-
-                string formatString = @"{0,-12} {1,-21} {2,-13} {3,-21} {4,-15} {5,-17} {6,-15} {7}";
+                string versionLabel = ipVersion == IPVersion.IPv4 ? "IPv4" : "IPv6";
+                Beaprint.ColorPrint($"  Enumerating {versionLabel} connections\n", Beaprint.LBLUE);
 
                 Beaprint.NoColorPrint(
                     string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address", "Remote Port", "State", "Process ID", "Process Name"));
 
-                foreach (var tcpConnectionInfo in NetworkInfoHelper.GetTcpConnections(IPVersion.IPv4, processesByPid))
+                foreach (var tcpConnectionInfo in NetworkInfoHelper.GetTcpConnections(ipVersion, processesByPid))
                 {
                     Beaprint.AnsiPrint(
                         string.Format(formatString,
                                        "  TCP",
-                                       tcpConnectionInfo.LocalAddress,
+                                       addressFormatter(tcpConnectionInfo.LocalAddress),
                                        tcpConnectionInfo.LocalPort,
-                                       tcpConnectionInfo.RemoteAddress,
-                                       tcpConnectionInfo.RemotePort,
-                                       tcpConnectionInfo.State.GetDescription(),
-                                       tcpConnectionInfo.ProcessId,
-                                       tcpConnectionInfo.ProcessName
-                                     ),
-                                     colorsN);
-                }
-            }
-            catch (Exception ex)
-            {
-                Beaprint.PrintException(ex.Message);
-            }
-        }
-
-        private void PrintListeningPortsTcpIPv6(Dictionary<int, Process> processesByPid)
-        {
-            try
-            {
-                Beaprint.ColorPrint("  Enumerating IPv6 connections\n", Beaprint.LBLUE);
-
-                string formatString = @"{0,-12} {1,-43} {2,-13} {3,-43} {4,-15} {5,-17} {6,-15} {7}";
-
-                Beaprint.NoColorPrint(
-                    string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address", "Remote Port", "State", "Process ID", "Process Name"));
-
-                foreach (var tcpConnectionInfo in NetworkInfoHelper.GetTcpConnections(IPVersion.IPv6, processesByPid))
-                {
-                    Beaprint.AnsiPrint(
-                        string.Format(formatString,
-                                       "  TCP",
-                                       $"[{tcpConnectionInfo.LocalAddress}]",
-                                       tcpConnectionInfo.LocalPort,
-                                       $"[{tcpConnectionInfo.RemoteAddress}]",
+                                       addressFormatter(tcpConnectionInfo.RemoteAddress),
                                        tcpConnectionInfo.RemotePort,
                                        tcpConnectionInfo.State.GetDescription(),
                                        tcpConnectionInfo.ProcessId,
@@ -217,23 +187,26 @@ namespace winPEAS.Checks
             Beaprint.MainPrint("Current UDP Listening Ports");
             Beaprint.LinkPrint("", "Check for services restricted from the outside");
 
-            PrintListeningPortsUdpIPv4(processesByPid);
+            PrintListeningPortsUdpByVersion(processesByPid, IPVersion.IPv4,
+                @"{0,-12} {1,-21} {2,-13} {3,-30} {4,-17} {5}",
+                address => address.ToString());
             Beaprint.ColorPrint("", Beaprint.NOCOLOR);
-            PrintListeningPortsUdpIPv6(processesByPid);
+            PrintListeningPortsUdpByVersion(processesByPid, IPVersion.IPv6,
+                @"{0,-12} {1,-43} {2,-13} {3,-30} {4,-17} {5}",
+                address => $"[{address}]");
         }
 
-        private void PrintListeningPortsUdpIPv4(Dictionary<int, Process> processesByPid)
+        private void PrintListeningPortsUdpByVersion(Dictionary<int, Process> processesByPid, IPVersion ipVersion, string formatString, Func<System.Net.IPAddress, string> addressFormatter)
         {
             try
             {
-                Beaprint.ColorPrint("  Enumerating IPv4 connections\n", Beaprint.LBLUE);
-
-                string formatString = @"{0,-12} {1,-21} {2,-13} {3,-30} {4,-17} {5}";
+                string versionLabel = ipVersion == IPVersion.IPv4 ? "IPv4" : "IPv6";
+                Beaprint.ColorPrint($"  Enumerating {versionLabel} connections\n", Beaprint.LBLUE);
 
                 Beaprint.NoColorPrint(
                     string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address:Remote Port", "Process ID", "Process Name"));
 
-                foreach (var udpConnectionInfo in NetworkInfoHelper.GetUdpConnections(IPVersion.IPv4, processesByPid))
+                foreach (var udpConnectionInfo in NetworkInfoHelper.GetUdpConnections(ipVersion, processesByPid))
                 {
                     if (udpConnectionInfo.ProcessName == "dns") // Hundreds of them sometimes
                     {
@@ -243,43 +216,7 @@ namespace winPEAS.Checks
                     Beaprint.AnsiPrint(
                         string.Format(formatString,
                                        "  UDP",
-                                       udpConnectionInfo.LocalAddress,
-                                       udpConnectionInfo.LocalPort,
-                                       "*:*",   // UDP does not have remote address/port
-                                       udpConnectionInfo.ProcessId,
-                                       udpConnectionInfo.ProcessName
-                                     ),
-                                     colorsN);
-                }
-            }
-            catch (Exception ex)
-            {
-                Beaprint.PrintException(ex.Message);
-            }
-        }
-
-        private void PrintListeningPortsUdpIPv6(Dictionary<int, Process> processesByPid)
-        {
-            try
-            {
-                Beaprint.ColorPrint("  Enumerating IPv6 connections\n", Beaprint.LBLUE);
-
-                string formatString = @"{0,-12} {1,-43} {2,-13} {3,-30} {4,-17} {5}";
-
-                Beaprint.NoColorPrint(
-                    string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address:Remote Port", "Process ID", "Process Name"));
-
-                foreach (var udpConnectionInfo in NetworkInfoHelper.GetUdpConnections(IPVersion.IPv6, processesByPid))
-                {
-                    if (udpConnectionInfo.ProcessName == "dns") // Hundreds of them sometimes
-                    {
-                        continue;
-                    }
-
-                    Beaprint.AnsiPrint(
-                        string.Format(formatString,
-                                       "  UDP",
-                                       $"[{udpConnectionInfo.LocalAddress}]",
+                                       addressFormatter(udpConnectionInfo.LocalAddress),
                                        udpConnectionInfo.LocalPort,
                                        "*:*",   // UDP does not have remote address/port
                                        udpConnectionInfo.ProcessId,


### PR DESCRIPTION
Automated simplifications for winpeas checks.\n\nAgent summary:\nPEASS winpeas autoimprover agent completed successfully with 26 steps. Agent Comment: **Summary**
- Consolidated duplicated IPv4/IPv6 TCP and UDP listening port output into shared helpers while preserving exact output formatting in `winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs`.

**Tests**
- Not run (not requested).

If you want, I can run a quick build or targeted tests.\n\nGenerated by PEASS autoimprover workflow.