### PR TITLE
autoimprover: simplify winpeas checks

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs
@@ -141,63 +141,34 @@ namespace winPEAS.Checks
             Beaprint.MainPrint("Current TCP Listening Ports");
             Beaprint.LinkPrint("", "Check for services restricted from the outside");
 
-            PrintListeningPortsTcpIPv4(processesByPid);
+            PrintListeningPortsTcp(IPVersion.IPv4, processesByPid);
             Beaprint.ColorPrint("", Beaprint.NOCOLOR);
-            PrintListeningPortsTcpIPv6(processesByPid);
+            PrintListeningPortsTcp(IPVersion.IPv6, processesByPid);
         }
 
-        private void PrintListeningPortsTcpIPv4(Dictionary<int, Process> processesByPid)
+        private void PrintListeningPortsTcp(IPVersion ipVersion, Dictionary<int, Process> processesByPid)
         {
             try
             {
-                Beaprint.ColorPrint("  Enumerating IPv4 connections\n", Beaprint.LBLUE);
+                bool isIpv6 = ipVersion == IPVersion.IPv6;
+                string ipLabel = isIpv6 ? "IPv6" : "IPv4";
+                string formatString = isIpv6
+                    ? @"{0,-12} {1,-43} {2,-13} {3,-43} {4,-15} {5,-17} {6,-15} {7}"
+                    : @"{0,-12} {1,-21} {2,-13} {3,-21} {4,-15} {5,-17} {6,-15} {7}";
 
-                string formatString = @"{0,-12} {1,-21} {2,-13} {3,-21} {4,-15} {5,-17} {6,-15} {7}";
+                Beaprint.ColorPrint($"  Enumerating {ipLabel} connections\n", Beaprint.LBLUE);
 
                 Beaprint.NoColorPrint(
                     string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address", "Remote Port", "State", "Process ID", "Process Name"));
 
-                foreach (var tcpConnectionInfo in NetworkInfoHelper.GetTcpConnections(IPVersion.IPv4, processesByPid))
+                foreach (var tcpConnectionInfo in NetworkInfoHelper.GetTcpConnections(ipVersion, processesByPid))
                 {
                     Beaprint.AnsiPrint(
                         string.Format(formatString,
                                        "  TCP",
-                                       tcpConnectionInfo.LocalAddress,
+                                       isIpv6 ? $"[{tcpConnectionInfo.LocalAddress}]" : tcpConnectionInfo.LocalAddress,
                                        tcpConnectionInfo.LocalPort,
-                                       tcpConnectionInfo.RemoteAddress,
-                                       tcpConnectionInfo.RemotePort,
-                                       tcpConnectionInfo.State.GetDescription(),
-                                       tcpConnectionInfo.ProcessId,
-                                       tcpConnectionInfo.ProcessName
-                                     ),
-                                     colorsN);
-                }
-            }
-            catch (Exception ex)
-            {
-                Beaprint.PrintException(ex.Message);
-            }
-        }
-
-        private void PrintListeningPortsTcpIPv6(Dictionary<int, Process> processesByPid)
-        {
-            try
-            {
-                Beaprint.ColorPrint("  Enumerating IPv6 connections\n", Beaprint.LBLUE);
-
-                string formatString = @"{0,-12} {1,-43} {2,-13} {3,-43} {4,-15} {5,-17} {6,-15} {7}";
-
-                Beaprint.NoColorPrint(
-                    string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address", "Remote Port", "State", "Process ID", "Process Name"));
-
-                foreach (var tcpConnectionInfo in NetworkInfoHelper.GetTcpConnections(IPVersion.IPv6, processesByPid))
-                {
-                    Beaprint.AnsiPrint(
-                        string.Format(formatString,
-                                       "  TCP",
-                                       $"[{tcpConnectionInfo.LocalAddress}]",
-                                       tcpConnectionInfo.LocalPort,
-                                       $"[{tcpConnectionInfo.RemoteAddress}]",
+                                       isIpv6 ? $"[{tcpConnectionInfo.RemoteAddress}]" : tcpConnectionInfo.RemoteAddress,
                                        tcpConnectionInfo.RemotePort,
                                        tcpConnectionInfo.State.GetDescription(),
                                        tcpConnectionInfo.ProcessId,
@@ -217,23 +188,27 @@ namespace winPEAS.Checks
             Beaprint.MainPrint("Current UDP Listening Ports");
             Beaprint.LinkPrint("", "Check for services restricted from the outside");
 
-            PrintListeningPortsUdpIPv4(processesByPid);
+            PrintListeningPortsUdp(IPVersion.IPv4, processesByPid);
             Beaprint.ColorPrint("", Beaprint.NOCOLOR);
-            PrintListeningPortsUdpIPv6(processesByPid);
+            PrintListeningPortsUdp(IPVersion.IPv6, processesByPid);
         }
 
-        private void PrintListeningPortsUdpIPv4(Dictionary<int, Process> processesByPid)
+        private void PrintListeningPortsUdp(IPVersion ipVersion, Dictionary<int, Process> processesByPid)
         {
             try
             {
-                Beaprint.ColorPrint("  Enumerating IPv4 connections\n", Beaprint.LBLUE);
+                bool isIpv6 = ipVersion == IPVersion.IPv6;
+                string ipLabel = isIpv6 ? "IPv6" : "IPv4";
+                string formatString = isIpv6
+                    ? @"{0,-12} {1,-43} {2,-13} {3,-30} {4,-17} {5}"
+                    : @"{0,-12} {1,-21} {2,-13} {3,-30} {4,-17} {5}";
 
-                string formatString = @"{0,-12} {1,-21} {2,-13} {3,-30} {4,-17} {5}";
+                Beaprint.ColorPrint($"  Enumerating {ipLabel} connections\n", Beaprint.LBLUE);
 
                 Beaprint.NoColorPrint(
                     string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address:Remote Port", "Process ID", "Process Name"));
 
-                foreach (var udpConnectionInfo in NetworkInfoHelper.GetUdpConnections(IPVersion.IPv4, processesByPid))
+                foreach (var udpConnectionInfo in NetworkInfoHelper.GetUdpConnections(ipVersion, processesByPid))
                 {
                     if (udpConnectionInfo.ProcessName == "dns") // Hundreds of them sometimes
                     {
@@ -243,43 +218,7 @@ namespace winPEAS.Checks
                     Beaprint.AnsiPrint(
                         string.Format(formatString,
                                        "  UDP",
-                                       udpConnectionInfo.LocalAddress,
-                                       udpConnectionInfo.LocalPort,
-                                       "*:*",   // UDP does not have remote address/port
-                                       udpConnectionInfo.ProcessId,
-                                       udpConnectionInfo.ProcessName
-                                     ),
-                                     colorsN);
-                }
-            }
-            catch (Exception ex)
-            {
-                Beaprint.PrintException(ex.Message);
-            }
-        }
-
-        private void PrintListeningPortsUdpIPv6(Dictionary<int, Process> processesByPid)
-        {
-            try
-            {
-                Beaprint.ColorPrint("  Enumerating IPv6 connections\n", Beaprint.LBLUE);
-
-                string formatString = @"{0,-12} {1,-43} {2,-13} {3,-30} {4,-17} {5}";
-
-                Beaprint.NoColorPrint(
-                    string.Format($"{formatString}\n", "  Protocol", "Local Address", "Local Port", "Remote Address:Remote Port", "Process ID", "Process Name"));
-
-                foreach (var udpConnectionInfo in NetworkInfoHelper.GetUdpConnections(IPVersion.IPv6, processesByPid))
-                {
-                    if (udpConnectionInfo.ProcessName == "dns") // Hundreds of them sometimes
-                    {
-                        continue;
-                    }
-
-                    Beaprint.AnsiPrint(
-                        string.Format(formatString,
-                                       "  UDP",
-                                       $"[{udpConnectionInfo.LocalAddress}]",
+                                       isIpv6 ? $"[{udpConnectionInfo.LocalAddress}]" : udpConnectionInfo.LocalAddress,
                                        udpConnectionInfo.LocalPort,
                                        "*:*",   // UDP does not have remote address/port
                                        udpConnectionInfo.ProcessId,


### PR DESCRIPTION
Automated simplifications for winpeas checks.\n\nAgent summary:\nPEASS winpeas autoimprover agent completed successfully with 20 steps. Agent Comment: **Summary**
Refactored duplicated IPv4/IPv6 TCP and UDP listening port listing logic into shared helpers while preserving output formatting in `winPEAS/winPEASexe/winPEAS/Checks/NetworkInfo.cs`.
No README updates were needed because functionality and output remain unchanged.

**Tests**
Not run (not requested).\n\nGenerated by PEASS autoimprover workflow.