### PR TITLE
autoimprover: simplify winpeas checks

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/BrowserBase.cs
+++ b/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/BrowserBase.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using winPEAS.Checks;
 using winPEAS.Helpers;
 using winPEAS.KnownFileCreds.Browsers.Models;
 
@@ -7,6 +9,8 @@ namespace winPEAS.KnownFileCreds.Browsers
 {
     internal abstract class BrowserBase : IBrowser
     {
+        protected const string BrowserHistoryLink = "https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/index.html#browsers-history";
+
         public abstract string Name { get; }
         public abstract IEnumerable<CredentialModel> GetSavedCredentials();
         public abstract void PrintInfo();
@@ -33,6 +37,40 @@ namespace winPEAS.KnownFileCreds.Browsers
 
                     Beaprint.PrintLineSeparator();
                 }
+            }
+        }
+
+        protected static void PrintBrowserHistoryLink()
+        {
+            Beaprint.LinkPrint(BrowserHistoryLink);
+        }
+
+        protected static void PrintCredentialHistory(List<string> history, string browserName)
+        {
+            if (history.Count > 0)
+            {
+                Dictionary<string, string> colors = new Dictionary<string, string>
+                {
+                    { Globals.PrintCredStrings, Beaprint.ansi_color_bad },
+                };
+
+                foreach (string url in history)
+                {
+                    if (MyUtils.ContainsAnyRegex(url.ToUpper(), Browser.CredStringsRegex))
+                    {
+                        Beaprint.AnsiPrint("    " + url, colors);
+                    }
+                }
+
+                Console.WriteLine();
+
+                int limit = 50;
+                Beaprint.MainPrint($"{browserName} history -- limit {limit}\n");
+                Beaprint.ListPrint(history.Take(limit).ToList());
+            }
+            else
+            {
+                Beaprint.NotFoundPrint();
             }
         }
     }

--- a/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/Chrome/Chrome.cs
+++ b/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/Chrome/Chrome.cs
@@ -27,7 +27,7 @@ namespace winPEAS.KnownFileCreds.Browsers.Chrome
             try
             {
                 Beaprint.MainPrint("Looking for Chrome DBs");
-                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/index.html#browsers-history");
+                PrintBrowserHistoryLink();
                 Dictionary<string, string> chromeDBs = GetChromeDbs();
 
                 if (chromeDBs.ContainsKey("userChromeCookiesPath"))
@@ -59,35 +59,12 @@ namespace winPEAS.KnownFileCreds.Browsers.Chrome
             try
             {
                 Beaprint.MainPrint("Looking for GET credentials in Chrome history");
-                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/index.html#browsers-history");
+                PrintBrowserHistoryLink();
                 Dictionary<string, List<string>> chromeHistBook = GetChromeHistBook();
                 List<string> history = chromeHistBook["history"];
                 List<string> bookmarks = chromeHistBook["bookmarks"];
 
-                if (history.Count > 0)
-                {
-                    Dictionary<string, string> colorsB = new Dictionary<string, string>()
-                    {
-                        { Globals.PrintCredStrings, Beaprint.ansi_color_bad },
-                    };
-
-                    foreach (string url in history)
-                    {
-                        if (MyUtils.ContainsAnyRegex(url.ToUpper(), Browser.CredStringsRegex))
-                        {
-                            Beaprint.AnsiPrint("    " + url, colorsB);
-                        }
-                    }
-                    Console.WriteLine();
-
-                    int limit = 50;
-                    Beaprint.MainPrint($"Chrome history -- limit {limit}\n");
-                    Beaprint.ListPrint(history.Take(limit).ToList());
-                }
-                else
-                {
-                    Beaprint.NotFoundPrint();
-                }
+                PrintCredentialHistory(history, "Chrome");
 
                 Beaprint.MainPrint("Chrome bookmarks");
                 Beaprint.ListPrint(bookmarks);

--- a/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/Firefox/Firefox.cs
+++ b/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/Firefox/Firefox.cs
@@ -28,7 +28,7 @@ namespace winPEAS.KnownFileCreds.Browsers.Firefox
             try
             {
                 Beaprint.MainPrint("Looking for Firefox DBs");
-                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/index.html#browsers-history");
+                PrintBrowserHistoryLink();
                 List<string> firefoxDBs = GetFirefoxDbs();
                 if (firefoxDBs.Count > 0)
                 {
@@ -55,32 +55,9 @@ namespace winPEAS.KnownFileCreds.Browsers.Firefox
             try
             {
                 Beaprint.MainPrint("Looking for GET credentials in Firefox history");
-                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/index.html#browsers-history");
+                PrintBrowserHistoryLink();
                 List<string> history = GetFirefoxHistory();
-                if (history.Count > 0)
-                {
-                    Dictionary<string, string> colorsB = new Dictionary<string, string>()
-                    {
-                        { Globals.PrintCredStrings, Beaprint.ansi_color_bad },
-                    };
-
-                    foreach (string url in history)
-                    {
-                        if (MyUtils.ContainsAnyRegex(url.ToUpper(), Browser.CredStringsRegex))
-                        {
-                            Beaprint.AnsiPrint("    " + url, colorsB);
-                        }
-                    }
-                    Console.WriteLine();
-
-                    int limit = 50;
-                    Beaprint.MainPrint($"Firefox history -- limit {limit}\n");
-                    Beaprint.ListPrint(history.Take(limit).ToList());
-                }
-                else
-                {
-                    Beaprint.NotFoundPrint();
-                }
+                PrintCredentialHistory(history, "Firefox");
             }
             catch (Exception ex)
             {

--- a/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/InternetExplorer.cs
+++ b/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/InternetExplorer.cs
@@ -29,7 +29,7 @@ namespace winPEAS.KnownFileCreds.Browsers
             try
             {
                 Beaprint.MainPrint("Current IE tabs");
-                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/index.html#browsers-history");
+                PrintBrowserHistoryLink();
                 List<string> urls = GetCurrentIETabs();
 
                 Dictionary<string, string> colorsB = new Dictionary<string, string>()
@@ -50,35 +50,12 @@ namespace winPEAS.KnownFileCreds.Browsers
             try
             {
                 Beaprint.MainPrint("Looking for GET credentials in IE history");
-                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/index.html#browsers-history");
+                PrintBrowserHistoryLink();
                 Dictionary<string, List<string>> ieHistoryBook = GetIEHistFav();
                 List<string> history = ieHistoryBook["history"];
                 List<string> favorites = ieHistoryBook["favorites"];
 
-                if (history.Count > 0)
-                {
-                    Dictionary<string, string> colorsB = new Dictionary<string, string>()
-                    {
-                        { Globals.PrintCredStrings, Beaprint.ansi_color_bad },
-                    };
-
-                    foreach (string url in history)
-                    {
-                        if (MyUtils.ContainsAnyRegex(url.ToUpper(), Browser.CredStringsRegex))
-                        {
-                            Beaprint.AnsiPrint("    " + url, colorsB);
-                        }
-                    }
-                    Console.WriteLine();
-
-                    int limit = 50;
-                    Beaprint.MainPrint($"IE history -- limit {limit}\n");
-                    Beaprint.ListPrint(history.Take(limit).ToList());
-                }
-                else
-                {
-                    Beaprint.NotFoundPrint();
-                }
+                PrintCredentialHistory(history, "IE");
 
                 Beaprint.MainPrint("IE favorites");
                 Beaprint.ListPrint(favorites);


### PR DESCRIPTION
Automated simplifications for winpeas checks.\n\nAgent summary:\nPEASS winpeas autoimprover agent completed successfully with 42 steps. Agent Comment: I’m mapping the WinPEAS C# surface first, then I’ll inspect the last 30 days of git history on only those files before deciding on a minimal safe refactor.
I’m narrowing scope to the WinPEAS C# project only and collecting file layout plus candidate modules before touching history or code.
`rg` is unavailable here, so I’m falling back to `find`/`grep`. Next I’m isolating the actual C# project files and the recent commit set that touched them.
The 30-day history on the WinPEAS EXE tree is almost empty, which lowers refactor risk but also means I need to justify any change directly from current duplication in code. I’m reading the entrypoints and common helper/check modules now.
I’ve confirmed the recent-change surface is tiny. That makes a helper-level deduplication the safest option, so I’m checking orchestration code and a few shared modules for repetition that can be collapsed without touching check behavior.
I found a few low-risk duplication clusters in shared output code and browser credential/history checks. I’m reading those side by side to pick the smallest refactor that reduces repetition without altering emitted text.
The browser modules have a clean duplication seam: repeated HackTricks link printing and the same “highlight credential-looking URLs then show top 50 entries” block across Chrome, Firefox, and IE. I’m validating project/build constraints before I fold that shared logic into the browser base class.
I’m applying a narrow refactor in the browser base class and three browser modules. The goal is only to centralize repeated history-link and suspicious-URL printing while keeping output text unchanged.
The refactor is in. I’m checking the exact diff and then attempting a project build/test path to catch any compile issues from the shared helper extraction.
Build tooling is missing in this environment, so I can’t do a real compile. I’m doing one more pass for syntax-level risks and repository notes, then I’ll close out with the validated scope and limitation.
Scoped WinPEAS EXE work to the C# project under [winPEAS](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS), with entrypoint [Program.cs](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS/Program.cs) and orchestration in [Checks.cs](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS/Checks/Checks.cs). In the last 30 days, only one commit touched that tree: `2026-04-17` on [Beaprint.cs](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS/Helpers/Beaprint.cs), adding the LHE course URL.

I made one small safe refactor in the browser modules. [BrowserBase.cs](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/BrowserBase.cs) now owns the shared browsers-history HackTricks link and the repeated “highlight suspicious history URLs, then print the top 50” flow. [Chrome.cs](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/Chrome/Chrome.cs), [Firefox.cs](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/Firefox/Firefox.cs), and [InternetExplorer.cs](/tmp/peass-ng/winPEAS/winPEASexe/winPEAS/KnownFileCreds/Browsers/InternetExplorer.cs) now call those helpers instead of carrying near-identical blocks. This removed 79 lines of duplication and kept output text/behavior the same.

I did not change the README because there was no user-visible functionality change to document. I also could not run a real build here: `dotnet`, `msbuild`, `mono`, `csc`, `mcs`, and `xbuild` are all unavailable in this environment, so validation was limited to diff review and syntax-level inspection.\n\nGenerated by PEASS autoimprover workflow.