### PR TITLE
autoimprover: simplify linpeas checks

### DIFF
--- a/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh
+++ b/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh
@@ -9,7 +9,7 @@
 # Functions Used: echo_not_found, print_2title, print_info, print_3title
 # Global Variables: $capsB, $capsVB, $IAMROOT, $SEARCH_IN_FOLDER
 # Initial Functions:
-# Generated Global Variables: $cap_name, $cap_value, $cap_line, $capVB, $capname, $capbins, $capsVB_vuln, $proc_status, $proc_pid, $proc_name, $proc_uid, $user_name, $proc_inh, $proc_prm, $proc_eff, $proc_bnd, $proc_amb, $proc_inh_dec, $proc_prm_dec, $proc_eff_dec, $proc_bnd_dec, $proc_amb_dec
+# Generated Global Variables: $cap_name, $cap_value, $cap_line, $cap_status_file, $cap_default_sep, $cap_sep, $cap_color, $capVB, $capname, $capbins, $capsVB_vuln, $proc_status, $proc_pid, $proc_name, $proc_uid, $user_name, $proc_inh, $proc_prm, $proc_eff, $proc_bnd, $proc_amb, $proc_inh_dec, $proc_prm_dec, $proc_eff_dec, $proc_bnd_dec, $proc_amb_dec
 # Fat linpeas: 0
 # Small linpeas: 1
 
@@ -27,57 +27,36 @@ if ! [ "$SEARCH_IN_FOLDER" ]; then
       return 0
     }
 
+    print_cap_status() {
+      cap_status_file="$1"
+      cap_default_sep="$2"
+
+      cat "$cap_status_file" | grep Cap | while read -r cap_line; do
+        cap_name=$(echo "$cap_line" | awk '{print $1}')
+        cap_value=$(echo "$cap_line" | awk '{print $2}')
+        cap_sep="$cap_default_sep"
+        cap_color="$SED_RED"
+
+        if [ "$cap_name" = "CapEff:" ]; then
+          cap_sep="	 "
+          cap_color="$SED_RED_YELLOW"
+        fi
+
+        if is_hex_cap_value "$cap_value"; then
+          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
+          # so we redirect stderr to prevent error propagation
+          echo "$cap_name$cap_sep$(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${cap_color},")"
+        else
+          echo "$cap_name$cap_sep[Invalid capability format]"
+        fi
+      done
+    }
+
     print_3title "Current shell capabilities" "T1548.001"
-    cat "/proc/$$/status" | grep Cap | while read -r cap_line; do
-      cap_name=$(echo "$cap_line" | awk '{print $1}')
-      cap_value=$(echo "$cap_line" | awk '{print $2}')
-      if [ "$cap_name" = "CapEff:" ]; then
-        # Add validation check for cap_value
-        # For more POSIX-compliant formatting, the following could be used instead:
-        # if echo "$cap_value" | grep -E '^[0-9a-fA-F]+$' > /dev/null 2>&1; then
-        if is_hex_cap_value "$cap_value"; then
-          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
-          # so we redirect stderr to prevent error propagation
-          echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
-        else
-          echo "$cap_name	 [Invalid capability format]"
-        fi
-      else
-        # Add validation check for cap_value
-        if is_hex_cap_value "$cap_value"; then
-          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
-          # so we redirect stderr to prevent error propagation
-          echo "$cap_name  $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED},")"
-        else
-          echo "$cap_name  [Invalid capability format]"
-        fi
-      fi
-    done
+    print_cap_status "/proc/$$/status" "  "
     echo ""
     print_info "Parent process capabilities"
-    cat "/proc/$PPID/status" | grep Cap | while read -r cap_line; do
-      cap_name=$(echo "$cap_line" | awk '{print $1}')
-      cap_value=$(echo "$cap_line" | awk '{print $2}')
-      if [ "$cap_name" = "CapEff:" ]; then
-        # Add validation check for cap_value
-        if is_hex_cap_value "$cap_value"; then
-          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
-          # so we redirect stderr to prevent error propagation
-          echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
-        else
-          echo "$cap_name	 [Invalid capability format]"
-        fi
-      else
-        # Add validation check for cap_value
-        if is_hex_cap_value "$cap_value"; then
-          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
-          # so we redirect stderr to prevent error propagation
-          echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED},")"
-        else
-          echo "$cap_name	 [Invalid capability format]"
-        fi
-      fi
-    done
+    print_cap_status "/proc/$PPID/status" "	 "
     echo ""
 
     print_3title "Processes with capability sets (non-zero CapEff/CapAmb, limit 40)" "T1548.001"


### PR DESCRIPTION
Automated simplifications for linpeas checks.\n\nAgent summary:\nPEASS linpeas autoimprover agent completed successfully with 32 steps. Agent Comment: I’m mapping the linpeas-specific code paths first, then I’ll trace the last 30 days of commits on only those files so the refactor stays local and low risk.
`rg` isn’t installed here, so I’m falling back to `find`, `grep`, and git plumbing. Next I’m narrowing to `linPEAS` files and recent history touching them.
The recent activity is concentrated in four linpeas part files. I’m opening those files and the surrounding builder structure now to look for duplication patterns that can be merged without altering output.
I found the safest simplification point: `4_Capabilities.sh` repeats the same decode-and-validate logic across the shell and parent capability blocks. I’m extracting that repeated logic into a small helper while keeping the emitted text and highlighting unchanged.
I have the refactor scoped to one module and I’m not touching check behavior or output structure. The edit is limited to extracting the duplicated capability-line rendering into a helper and updating metadata for the helper’s scratch variables.
The module parses cleanly. The full builder is running now; I’m waiting on that before I close out so the refactor is verified against the generated linpeas output.
The builder succeeded from the `linPEAS` directory. I’m checking the exact repo-root invocation next because your validation rule calls that command form out explicitly, and I want to report the real behavior rather than assume it’s equivalent.
Reviewed only `linPEAS` and the last 30 days of linpeas-related commits. The recent touch points were `PackageKit_Pack2TheRoot.sh`, `0_variables_base.sh`, `writeVB.sh`, and [4_Capabilities.sh](/tmp/peass-ng/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh:1). The only safe deduplication I found worth changing was in `4_Capabilities.sh`.

I refactored [4_Capabilities.sh](/tmp/peass-ng/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh:30) to extract the repeated capability-line decode/render logic into `print_cap_status()`. That removes the duplicated shell/parent loops while preserving the same checks, coloring, and output layout. I also updated the module metadata for the helper’s scratch variables at [4_Capabilities.sh](/tmp/peass-ng/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh:12). No README changes were needed because behavior did not change.

Validation:
- `sh -n linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh` succeeded.
- `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh` succeeded from `/tmp/peass-ng/linPEAS` and produced `/tmp/linpeas_fat.sh`.
- The exact same module invocation from repo root `/tmp/peass-ng` fails with `ModuleNotFoundError: No module named 'builder'`, because the `builder` package is under `linPEAS/`.\n\nGenerated by PEASS autoimprover workflow.