### PR TITLE
autoimprover: simplify linpeas checks

### DIFF
--- a/linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh
@@ -56,6 +56,13 @@ az_vm_print_token() {
   echo ""
 }
 
+az_vm_print_standard_tokens() {
+  az_vm_print_token "Management token$1" "https://management.azure.com/" "$2"
+  az_vm_print_token "Graph token$1" "https://graph.microsoft.com/" "$2"
+  az_vm_print_token "Vault token$1" "https://vault.azure.net/" "$2"
+  az_vm_print_token "Storage token$1" "https://storage.azure.com/" "$2"
+}
+
 az_vm_request_wireserver() {
   _az_vm_wire_header="$1"
   _az_vm_wire_url="$2"
@@ -91,20 +98,14 @@ az_vm_try_wire_identity_tokens() {
       printf "%s" "$_az_vm_wire_data" | jq -r '.. | objects | to_entries[]? | select((.key|test("(?i)(clientId|IdentityClientId)$")) and (.value|type=="string")) | .value' 2>/dev/null | sort -u | while read -r _az_vm_wire_client_id; do
         if printf "%s" "$_az_vm_wire_client_id" | grep -Eq '^[0-9a-fA-F-]{36}$'; then
           print_info "Trying IMDS tokens for WireServer-discovered client_id=$_az_vm_wire_client_id"
-          az_vm_print_token "Management token for WireServer client_id $_az_vm_wire_client_id" "https://management.azure.com/" "client_id=$_az_vm_wire_client_id"
-          az_vm_print_token "Graph token for WireServer client_id $_az_vm_wire_client_id" "https://graph.microsoft.com/" "client_id=$_az_vm_wire_client_id"
-          az_vm_print_token "Vault token for WireServer client_id $_az_vm_wire_client_id" "https://vault.azure.net/" "client_id=$_az_vm_wire_client_id"
-          az_vm_print_token "Storage token for WireServer client_id $_az_vm_wire_client_id" "https://storage.azure.com/" "client_id=$_az_vm_wire_client_id"
+          az_vm_print_standard_tokens " for WireServer client_id $_az_vm_wire_client_id" "client_id=$_az_vm_wire_client_id"
         fi
       done
     fi
 
     printf "%s\n" "$_az_vm_wire_data" | grep -Eio '/subscriptions/[^"<>[:space:]]+/resourceGroups/[^"<>[:space:]]+/providers/Microsoft\.ManagedIdentity/userAssignedIdentities/[^"<>[:space:]]+' | sort -u | while read -r _az_vm_wire_res_id; do
       print_info "Trying IMDS tokens for WireServer-discovered msi_res_id=$_az_vm_wire_res_id"
-      az_vm_print_token "Management token for WireServer msi_res_id" "https://management.azure.com/" "msi_res_id=$_az_vm_wire_res_id"
-      az_vm_print_token "Graph token for WireServer msi_res_id" "https://graph.microsoft.com/" "msi_res_id=$_az_vm_wire_res_id"
-      az_vm_print_token "Vault token for WireServer msi_res_id" "https://vault.azure.net/" "msi_res_id=$_az_vm_wire_res_id"
-      az_vm_print_token "Storage token for WireServer msi_res_id" "https://storage.azure.com/" "msi_res_id=$_az_vm_wire_res_id"
+      az_vm_print_standard_tokens " for WireServer msi_res_id" "msi_res_id=$_az_vm_wire_res_id"
     done
   else
     echo "WireServer/HostGAPlugin did not return data from this context."
@@ -180,10 +181,7 @@ if [ "$is_az_vm" = "Yes" ]; then
           printf "%s" "$_az_vm_arm_json" | jq -r '.identity.userAssignedIdentities // {} | to_entries[] | [.key, .value.clientId, .value.principalId] | @tsv' 2>/dev/null | while IFS="$(printf '\t')" read -r _az_vm_uai_id _az_vm_uai_client_id _az_vm_uai_principal_id; do
             if [ "$_az_vm_uai_client_id" ]; then
               print_info "Requesting tokens for UAI client_id=$_az_vm_uai_client_id principal_id=$_az_vm_uai_principal_id resource_id=$_az_vm_uai_id"
-              az_vm_print_token "Management token for UAI $_az_vm_uai_client_id" "https://management.azure.com/" "client_id=$_az_vm_uai_client_id"
-              az_vm_print_token "Graph token for UAI $_az_vm_uai_client_id" "https://graph.microsoft.com/" "client_id=$_az_vm_uai_client_id"
-              az_vm_print_token "Vault token for UAI $_az_vm_uai_client_id" "https://vault.azure.net/" "client_id=$_az_vm_uai_client_id"
-              az_vm_print_token "Storage token for UAI $_az_vm_uai_client_id" "https://storage.azure.com/" "client_id=$_az_vm_uai_client_id"
+              az_vm_print_standard_tokens " for UAI $_az_vm_uai_client_id" "client_id=$_az_vm_uai_client_id"
             fi
           done
         else

--- a/linPEAS/builder/linpeas_parts/6_users_information/7_Sudo_l.sh
+++ b/linPEAS/builder/linpeas_parts/6_users_information/7_Sudo_l.sh
@@ -17,13 +17,25 @@
 print_2title "Checking 'sudo -l', /etc/sudoers, and /etc/sudoers.d" "T1548.003"
 print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/index.html#sudo-and-suid"
 
+sudo_l_colorize() {
+  sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g"
+}
+
+sudo_l_colorize_output() {
+  printf "%s\n" "$1" | sudo_l_colorize | sed "s,\!root,${SED_RED},"
+}
+
+sudo_l_colorize_file() {
+  grep -Iv "^$" "$1" | grep -v "#" | sudo_l_colorize | sed "s,pwfeedback,${SED_RED},g"
+}
+
 if [ "$(command -v sudo 2>/dev/null || echo -n '')" ]; then
   if [ "$TIMEOUT" ]; then
     sudo_l_output=$(printf '\n' | "$TIMEOUT" 15 sudo -S -l 2>/dev/null)
   else
     sudo_l_output=$(sudo -n -l 2>/dev/null)
   fi
-  printf "%s\n" "$sudo_l_output" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g" | sed "s,\!root,${SED_RED},"
+  sudo_l_colorize_output "$sudo_l_output"
 
   if [ "$PASSWORD" ]; then
     if [ "$TIMEOUT" ]; then
@@ -31,12 +43,12 @@ if [ "$(command -v sudo 2>/dev/null || echo -n '')" ]; then
     else
       sudo_l_password_output=$(printf "%s\n" "$PASSWORD" | sudo -S -l 2>/dev/null)
     fi
-    printf "%s\n" "$sudo_l_password_output" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g"
+    printf "%s\n" "$sudo_l_password_output" | sudo_l_colorize
   fi
 
   sudo_l_cached_output=$(sudo -n -l 2>/dev/null)
   if [ "$sudo_l_cached_output" ]; then
-    printf "%s\n" "$sudo_l_cached_output" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g" | sed "s,\!root,${SED_RED},"
+    sudo_l_colorize_output "$sudo_l_cached_output"
   else
     echo "No cached sudo token (sudo -n -l)"
   fi
@@ -52,7 +64,7 @@ if [ "$secure_path_line" ]; then
     fi
   done
 fi
-( grep -Iv "^$" cat /etc/sudoers | grep -v "#" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g" | sed "s,pwfeedback,${SED_RED},g" ) 2>/dev/null  || echo_not_found "/etc/sudoers"
+(sudo_l_colorize_file /etc/sudoers) 2>/dev/null || echo_not_found "/etc/sudoers"
 if ! [ "$IAMROOT" ] && [ -w '/etc/sudoers.d/' ]; then
   echo "You can create a file in /etc/sudoers.d/ and escalate privileges" | sed -${E} "s,.*,${SED_RED_YELLOW},"
 fi
@@ -62,7 +74,7 @@ for f in /etc/sudoers.d/*; do
   fi
   if [ -r "$f" ]; then
     echo "Sudoers file: $f is readable" | sed -${E} "s,.*,${SED_RED},g"
-    grep -Iv "^$" "$f" | grep -v "#" | sed "s,_proxy,${SED_RED},g" | sed "s,$sudoG,${SED_GREEN},g" | sed -${E} "s,$sudoVB1,${SED_RED_YELLOW}," | sed -${E} "s,$sudoVB2,${SED_RED_YELLOW}," | sed -${E} "s,$sudoB,${SED_RED},g" | sed "s,pwfeedback,${SED_RED},g"
+    sudo_l_colorize_file "$f"
   fi
 done
 echo ""


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Simplified linpeas checks based on recent PEASS changes. -->\n\nAutomated simplifications for linpeas checks.\n\nAgent summary:\nPEASS linpeas autoimprover agent completed successfully with 31 steps. Agent Comment: Done.

**Main linpeas code locations reviewed**
- `linPEAS/builder/linpeas_parts/` — linpeas checks/modules
- `linPEAS/builder/linpeas_parts/functions/` — shared shell helpers
- `linPEAS/builder/src/` — builder logic
- `linPEAS/README.md` — docs (no update needed because behavior/output did not change)

**Recent linpeas commits inspected (last 30 days, since 2026-05-01)**
- `2026-05-28` `195fc24` — `checkCopyFail.sh`, tests
- `2026-05-25` `e5f01f3` — kernel CVE registry data
- `2026-05-21` `ca743bf` — bounded `sudo -l` checks
- `2026-05-21` `1ea8107` — builder exclude matching
- `2026-05-10` `0d6dab6` — Dirty Frag check
- `2026-05-05` `15a244c` — Azure VM managed identity discovery

**Safe refactors applied**
1. **Azure VM module**
   - File: `linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh`
   - Added `az_vm_print_standard_tokens()`
   - Replaced 3 duplicated 4-call token blocks:
     - WireServer `client_id`
     - WireServer `msi_res_id`
     - UAI `client_id`
   - Result: less repetition, same token titles/requests/output

2. **Sudo module**
   - File: `linPEAS/builder/linpeas_parts/6_users_information/7_Sudo_l.sh`
   - Added small helpers:
     - `sudo_l_colorize()`
     - `sudo_l_colorize_output()`
     - `sudo_l_colorize_file()`
   - Reused them for:
     - `sudo -l` output
     - password-based `sudo -l`
     - cached token `sudo -n -l`
     - `/etc/sudoers`
     - `/etc/sudoers.d/*`
   - Result: same formatting/highlighting behavior with less duplicated sed logic

**Validation**
- Syntax checked modified modules with `sh -n`
- Ran:
  - `python3 -m unittest linPEAS.tests.test_modules_metadata -v`
- Build succeeded:
  - `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh`
- Verified output:
  - `/tmp/linpeas_fat.sh` created
  - executable: **yes**

**Net effect**
- 2 files changed
- minimal, low-risk deduplication only
- no new checks/features
- no useful checks removed
- output format preserved\n\nGenerated by PEASS autoimprover workflow.