### PR TITLE
wordlist-updater: refresh linpeas vulnerability lists

### DIFF
--- a/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
+++ b/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
@@ -1,7 +1,7 @@
 # Title: Variables - kernel_cve_registry_data
 # ID: kernel_cve_registry_data
 # Author: Carlos Polop
-# Last Update: 25-05-2026
+# Last Update: 08-06-2026
 # Description: Embedded kernel exploit matching datasets extracted from linux-exploit-suggester and linux-exploit-suggester-2 examples. Data is split across KERNEL_CVE_DATA_1..X with a maximum of 25 rows per env variable. This file also stores reference-only CVE tokens found in example repos when no explicit suggester matching rule exists.
 # License: GNU GPL
 # Version: 1.0
@@ -609,5 +609,9 @@ CVE-2026-31431	Copy Fail	pkg=linux-kernel,ver>=6.19,ver<6.19.12,CONFIG_CRYPTO_US
 CVE-2017-16994	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from example repos; appears as related bypass mention
 CVE-2020-27171	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from example repos; appears as related comment in exploit source
 CVE-2024-0193	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from example repos; appears as upstream source reference
+CVE-2026-43284	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat Dirty Frag advisories; no stable matcher added
+CVE-2026-43500	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat Dirty Frag advisories; no stable matcher added
+CVE-2026-46243	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Red Hat CIFSwitch advisory; no stable matcher added
+CVE-2026-46300	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat Fragnesia advisories; no stable matcher added
 EOF_DATA_21
 )"


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Refreshed LinPEAS vulnerability wordlists. -->\n\nAutomated LinPEAS vulnerability wordlist refresh.\n\nAgent summary:\nPEASS linpeas wordlist updater completed successfully with 59 steps. Agent Comment: Done.

- **Files updated**
  - `linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh`

- **What data was refreshed**
  - Updated `Last Update` to `08-06-2026`
  - Added recent kernel CVEs as `catalog_reference_only` entries:
    - `CVE-2026-43284` (Dirty Frag)
    - `CVE-2026-43500` (Dirty Frag)
    - `CVE-2026-46243` (CIFSwitch)
    - `CVE-2026-46300` (Fragnesia)

- **Files reviewed but left unchanged**
  - `sidB.sh`: no reliable recent SUID-version additions found worth a safe list-only change
  - `sudovB.sh`: left unchanged because current regex already covers the published affected sudo ranges, including the June 30, 2025 sudo advisories

- **Build validation result**
  - Passed:
    - `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh`
  - Output created at:
    - `/tmp/linpeas_fat.sh`

- **Skipped items**
  - No matcher/range rules were added for the new 2026 kernel CVEs; I added them only as `catalog_reference_only` because I did not have stable, high-confidence upstream version-match boundaries suitable for LinPEAS’ rule format.
  - `sidB.sh` and `sudovB.sh` were intentionally not modified.

Sources used:
- https://www.sudo.ws/security/advisories/
- https://www.sudo.ws/security/advisories/host_any/
- https://www.sudo.ws/security/advisories/chroot_bug/
- https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available
- https://ubuntu.com/blog/fragnesia-linux-vulnerability-fixes-available
- https://access.redhat.com/security/vulnerabilities/RHSB-2026-003
- https://access.redhat.com/security/vulnerabilities/RHSB-2026-005
- https://nvd.nist.gov/vuln/detail/CVE-2026-43284
- https://nvd.nist.gov/vuln/detail/CVE-2026-43500
- https://nvd.nist.gov/vuln/detail/CVE-2026-46300\n\nGenerated by PEASS wordlist updater workflow.