### PR TITLE
kernel registry: add CVE-2026-46333 ptrace exit-race (ssh-keysign-pwn)

### DIFF
--- a/linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh
+++ b/linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh
@@ -3,11 +3,11 @@
 # Author: Carlos Polop
 # Last Update: 25-02-2026
 # Description: Evaluate declared kernel CVE rules using kernel version, arch, kernel config, sysctl and command prerequisites.
-# Description: Data source chunks KERNEL_CVE_DATA_1..21 are capped to 25 rows each.
+# Description: Data source chunks KERNEL_CVE_DATA_1..22 are capped to 25 rows each.
 # License: GNU GPL
 # Version: 1.0
 # Functions Used: echo_not_found, print_3title, print_list
-# Global Variables: $E, $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $SED_GREEN, $SED_RED_YELLOW
+# Global Variables: $E, $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $SED_GREEN, $SED_RED_YELLOW
 # Initial Functions: echo_not_found, print_3title, print_list
 # Generated Global Variables: $KERNEL_CVE_CFG_FILE, $KERNEL_CVE_CFG_SOURCE, $KERNEL_CVE_CFG_LINE, $KERNEL_CVE_CFG_KEY, $KERNEL_CVE_CFG_EXPR, $KERNEL_CVE_CFG_EXPECT, $KERNEL_CVE_CFG_OP, $KERNEL_CVE_CFG_CUR, $KERNEL_CVE_SYS_EXPR, $KERNEL_CVE_SYS_KEY, $KERNEL_CVE_SYS_OP, $KERNEL_CVE_SYS_VAL, $KERNEL_CVE_SYS_CUR, $KERNEL_CVE_REQS, $KERNEL_CVE_REQ, $KERNEL_CVE_REQ_LINES, $KERNEL_CVE_ID, $KERNEL_CVE_ID_NORM, $KERNEL_CVE_NAME, $KERNEL_CVE_TAGS, $KERNEL_CVE_RANK, $KERNEL_CVE_COMMENTS, $KERNEL_CVE_EXPL, $KERNEL_CVE_VERS, $KERNEL_CVE_VER_LINES, $KERNEL_CVE_ALT, $KERNEL_CVE_MIL, $KERNEL_CVE_TOKEN_OK, $KERNEL_CVE_MATCHES, $KERNEL_CVE_KERNEL_RELEASE, $KERNEL_CVE_KERNEL_VERSION, $KERNEL_CVE_KERNEL_ARCH, $KERNEL_CVE_KERNEL_OS, $KERNEL_CVE_VER, $KERNEL_CVE_OP, $KERNEL_CVE_REQVER, $KERNEL_CVE_CURVER, $KERNEL_CVE_CMP, $KERNEL_CVE_PRINT_ID, $KERNEL_CVE_PRINT_REASON, $KERNEL_CVE_ID_RAW, $KERNEL_CVE_ID_ITEM, $KERNEL_CVE_ID_OUT, $KERNEL_CVE_ALL_DATA, $KERNEL_CVE_PRINT_LINE
 # Fat linpeas: 0
@@ -257,17 +257,17 @@ kercve_run_registry() {
         fi
     done
 
-    KERNEL_CVE_ALL_DATA=$(printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s" \
+    KERNEL_CVE_ALL_DATA=$(printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s" \
         "$KERNEL_CVE_DATA_1" "$KERNEL_CVE_DATA_2" "$KERNEL_CVE_DATA_3" "$KERNEL_CVE_DATA_4" "$KERNEL_CVE_DATA_5" \
         "$KERNEL_CVE_DATA_6" "$KERNEL_CVE_DATA_7" "$KERNEL_CVE_DATA_8" "$KERNEL_CVE_DATA_9" "$KERNEL_CVE_DATA_10" \
         "$KERNEL_CVE_DATA_11" "$KERNEL_CVE_DATA_12" "$KERNEL_CVE_DATA_13" "$KERNEL_CVE_DATA_14" "$KERNEL_CVE_DATA_15" \
         "$KERNEL_CVE_DATA_16" "$KERNEL_CVE_DATA_17" "$KERNEL_CVE_DATA_18" "$KERNEL_CVE_DATA_19" "$KERNEL_CVE_DATA_20" \
-        "$KERNEL_CVE_DATA_21")
+        "$KERNEL_CVE_DATA_21" "$KERNEL_CVE_DATA_22")
 
     print_list "Operating system ............. $KERNEL_CVE_KERNEL_OS\n"
     print_list "Kernel release ............... $KERNEL_CVE_KERNEL_RELEASE\n"
     print_list "Comparable version ........... $KERNEL_CVE_KERNEL_VERSION\n"
-    print_list "Data chunk limit ............. max 25 rows per KERNEL_CVE_DATA_* variable (1..21)\n"
+    print_list "Data chunk limit ............. max 25 rows per KERNEL_CVE_DATA_* variable (1..22)\n"
     if [ -n "$KERNEL_CVE_CFG_SOURCE" ]; then
         print_list "Kernel config source ......... $KERNEL_CVE_CFG_SOURCE\n"
     else

--- a/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
+++ b/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
@@ -1,14 +1,14 @@
 # Title: Variables - kernel_cve_registry_data
 # ID: kernel_cve_registry_data
 # Author: Carlos Polop
-# Last Update: 08-06-2026
+# Last Update: 11-06-2026
 # Description: Embedded kernel exploit matching datasets extracted from linux-exploit-suggester and linux-exploit-suggester-2 examples. Data is split across KERNEL_CVE_DATA_1..X with a maximum of 25 rows per env variable. This file also stores reference-only CVE tokens found in example repos when no explicit suggester matching rule exists.
 # License: GNU GPL
 # Version: 1.0
 # Functions Used:
 # Global Variables:
 # Initial Functions:
-# Generated Global Variables: $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21
+# Generated Global Variables: $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22
 # Fat linpeas: 0
 # Small linpeas: 1
 
@@ -614,4 +614,19 @@ CVE-2026-43500	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token
 CVE-2026-46243	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Red Hat CIFSwitch advisory; no stable matcher added
 CVE-2026-46300	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat Fragnesia advisories; no stable matcher added
 EOF_DATA_21
+)"
+
+KERNEL_CVE_DATA_22="$(cat <<'EOF_DATA_22'
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=3.16.52,ver<3.17,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue backported into 3.16 at 3.16.52
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=4.4.40,ver<4.5,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue backported into 4.4 at 4.4.40
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=4.8.16,ver<4.9,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue backported into 4.8 at 4.8.16
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=4.9.1,ver<4.10,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue backported into 4.9 at 4.9.1
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=4.10,ver<5.10.256,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue introduced in 4.10; fixed in 5.10.256
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=5.11,ver<5.15.207,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue introduced in 4.10; fixed in 5.15.207
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=5.16,ver<6.1.173,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue introduced in 4.10; fixed in 6.1.173
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=6.2,ver<6.6.139,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue introduced in 4.10; fixed in 6.6.139
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=6.7,ver<6.12.89,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue introduced in 4.10; fixed in 6.12.89
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=6.13,ver<6.18.31,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue introduced in 4.10; fixed in 6.18.31
+CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=6.19,ver<7.0.8,sysctl:kernel.yama.ptrace_scope!=2		1	Upstream issue introduced in 4.10; fixed in 7.0.8
+EOF_DATA_22
 )"


### PR DESCRIPTION
**Add CVE-2026-46333 ("ssh-keysign-pwn") detection to the LinPEAS kernel exploit registry.**

Summary: local root privilege escalation / credential disclosure via a logic flaw in `__ptrace_may_access()` — during the process-exit window an unprivileged caller can use `pidfd_getfd(2)` to steal root-owned file descriptors (ssh-keysign host keys, `/etc/shadow`).

**Updated:**

* `linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh`
* `linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh`

**What changed:**

* Added `CVE-2026-46333` to the kernel registry in a new `KERNEL_CVE_DATA_22` chunk.
* Used split version ranges, keyed to the upstream stable fix versions, to avoid overmatching LTS backports:
  * `4.10` to `<5.10.256`
  * `5.11` to `<5.15.207`
  * `5.16` to `<6.1.173`
  * `6.2` to `<6.6.139`
  * `6.7` to `<6.12.89`
  * `6.13` to `<6.18.31`
  * `6.19` to `<7.0.8`
* Added the pre-4.10 stable-branch backport introductions (branches EOL'd without a fix):
  * `3.16.52` to `<3.17`
  * `4.4.40` to `<4.5`
  * `4.8.16` to `<4.9`
  * `4.9.1` to `<4.10`
* Added sysctl prerequisite so mitigated hosts are not flagged:
  * `sysctl:kernel.yama.ptrace_scope!=2`
* Wired the new chunk into the reader: extended the `KERNEL_CVE_ALL_DATA` concatenation and the `Global Variables` metadata in `kernel_cve_registry_checks.sh`, and bumped the chunk range to `1..22`.
* Updated the data file header date to `11-06-2026`.

**Build validation:**

* Passed: `python3 -m builder.linpeas_builder --include "Kernel_Exploit_Registry" --output /tmp/linpeas_kernel.sh`
* Passed: `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh`

**Notes:**

* `bash -n` syntax check clean on the generated output.
* The generated scripts contain all 11 `CVE-2026-46333` rows.
* Known limitation (accepted): matching is against upstream version ranges, so backported distro kernels (e.g. Ubuntu `7.0.0-22`, which carries the fix in the package revision) are still reported as *candidates* — consistent with the rest of the registry and linux-exploit-suggester behavior.

**Sources:**

* kernel.org CVE record https://git.kernel.org/pub/scm/linux/security/vulns.git/plain/cve/published/2026/CVE-2026-46333.mbox
* Qualys TRU advisory: https://blog.qualys.com/vulnerabilities-threat-research/2026/05/20/cve-2026-46333-local-root-privilege-escalation-and-credential-disclosure-in-the-linux-kernel-ptrace-path
* POC Tested: https://github.com/0xdeadbeefnetwork/ssh-keysign-pwn