### PR TITLE
wordlist-updater: refresh linpeas vulnerability lists

### DIFF
--- a/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
+++ b/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
@@ -1,7 +1,7 @@
 # Title: Variables - kernel_cve_registry_data
 # ID: kernel_cve_registry_data
 # Author: Carlos Polop
-# Last Update: 08-06-2026
+# Last Update: 22-06-2026
 # Description: Embedded kernel exploit matching datasets extracted from linux-exploit-suggester and linux-exploit-suggester-2 examples. Data is split across KERNEL_CVE_DATA_1..X with a maximum of 25 rows per env variable. This file also stores reference-only CVE tokens found in example repos when no explicit suggester matching rule exists.
 # License: GNU GPL
 # Version: 1.0
@@ -610,8 +610,10 @@ CVE-2017-16994	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token
 CVE-2020-27171	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from example repos; appears as related comment in exploit source
 CVE-2024-0193	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from example repos; appears as upstream source reference
 CVE-2026-43284	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat Dirty Frag advisories; no stable matcher added
+CVE-2026-43494	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu PinTheft advisory; no stable matcher added
 CVE-2026-43500	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat Dirty Frag advisories; no stable matcher added
 CVE-2026-46243	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Red Hat CIFSwitch advisory; no stable matcher added
 CVE-2026-46300	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat Fragnesia advisories; no stable matcher added
+CVE-2026-46333	catalog_reference_only	9999.9999.9999		0	Reference-only CVE token from official Ubuntu/Red Hat ssh-keysign-pwn advisories; no stable matcher added
 EOF_DATA_21
 )"


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Refreshed LinPEAS vulnerability wordlists. -->\n\nAutomated LinPEAS vulnerability wordlist refresh.\n\nAgent summary:\nPEASS linpeas wordlist updater completed successfully with 57 steps. Agent Comment: Done.

- **Files updated**
  - `linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh`

- **What data was refreshed**
  - Added **reference-only** kernel registry entries for:
    - `CVE-2026-43494` — PinTheft
    - `CVE-2026-46333` — ssh-keysign-pwn / process-exit race
  - Updated that file’s `Last Update` header to `22-06-2026`.

- **Files reviewed but left unchanged**
  - `linPEAS/builder/linpeas_parts/variables/sudovB.sh`
    - I checked recent official sudo advisories; current regex already covers the newly disclosed affected ranges up to `1.9.17` and older vulnerable branches, while not flagging the fixed `1.9.17p1`.
  - `linPEAS/builder/linpeas_parts/variables/sidB.sh`
    - No high-confidence, minimal, static list additions found that were safe to add.

- **Build validation result**
  - Passed:
    - `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh`
  - Output created at:
    - `/tmp/linpeas_fat.sh`

- **Skipped items / reason**
  - No direct matcher was added for `CVE-2026-43494` or `CVE-2026-46333`; I added them as **reference-only** entries because the exploitability conditions/version boundaries are more nuanced, and a broad matcher would risk false positives.
  - No sudo/SUID list edits were made because the current data already aligns with the official recent disclosures.

**Sources**
- Sudo advisory index: https://www.sudo.ws/security/advisories/
- Sudo host option advisory (`CVE-2025-32462`): https://www.sudo.ws/security/advisories/host_any/
- Sudo chroot advisory (`CVE-2025-32463`): https://www.sudo.ws/security/advisories/chroot_bug/
- Ubuntu PinTheft advisory (`CVE-2026-43494`): https://ubuntu.com/blog/pintheft-linux-kernel-vulnerability-mitigation
- Ubuntu ssh-keysign-pwn advisory (`CVE-2026-46333`): https://ubuntu.com/blog/ssh-keysign-pwn-linux-vulnerability-fixes-available
- Red Hat `CVE-2026-46333` bulletin: https://access.redhat.com/security/vulnerabilities/RHSB-2026-004\n\nGenerated by PEASS wordlist updater workflow.