### PR TITLE
autoimprover: simplify winpeas checks

### DIFF
--- a/winPEAS/winPEASexe/README.md
+++ b/winPEAS/winPEASexe/README.md
@@ -66,6 +66,7 @@ winpeas.exe domain #enumerate also domain information
 winpeas.exe wait #wait for user input between tests
 winpeas.exe debug #display additional debug information
 winpeas.exe log #log output to out.txt instead of standard output
+winpeas.exe -vulnpackages #send installed package names/versions to the optional HackTricks online lookup to flag vulnerable packages
 winpeas.exe -linpeas=http://127.0.0.1/linpeas.sh #Execute also additional linpeas check (runs linpeas.sh in default WSL distribution) with custom linpeas.sh URL (if not provided, the default URL is: https://raw.githubusercontent.com/peass-ng/PEASS-ng/master/linPEAS/linpeas.sh)
 winpeas.exe -lolbas  #Execute also additional LOLBAS search check
 ```
@@ -176,6 +177,7 @@ Once you have installed and activated it you need to:
 - **Applications Information**
   - [x] Current Active Window
   - [x] Installed software
+  - [x] Optional online installed-package vulnerability lookup via HackTricks (`-vulnpackages` or `all`)
   - [x] AutoRuns
   - [x] Scheduled tasks
   - [x] Device drivers
@@ -189,6 +191,8 @@ Once you have installed and activated it you need to:
   - [x] Firewall rules
   - [x] DNS Cache (limit 70)
   - [x] Internet Settings
+  - [x] Internet connectivity probes
+  - [x] Optional external hostname resolution check
 
 - **Cloud Metadata Enumeration**
   - [x] AWS Metadata

--- a/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/InstalledPackageInventory.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/InstalledPackageInventory.cs
@@ -1,7 +1,6 @@
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace winPEAS.Info.ApplicationInfo
 {
@@ -57,30 +56,16 @@ namespace winPEAS.Info.ApplicationInfo
                                 continue;
                             }
 
-                            var name = CleanValue(appKey.GetValue("DisplayName"));
-                            var version = CleanValue(appKey.GetValue("DisplayVersion"));
-                            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(version))
+                            var package = CreatePackage(appKey);
+                            if (package == null)
                             {
                                 continue;
                             }
 
-                            var key = $"{name}\0{version}";
+                            var key = $"{package["name"]}\0{package["version"]}";
                             if (!seen.Add(key))
                             {
                                 continue;
-                            }
-
-                            var package = new Dictionary<string, string>
-                            {
-                                { "name", name },
-                                { "version", version },
-                                { "manager", "windows-registry" }
-                            };
-
-                            var publisher = CleanValue(appKey.GetValue("Publisher"));
-                            if (!string.IsNullOrWhiteSpace(publisher))
-                            {
-                                package["publisher"] = publisher;
                             }
 
                             packages.Add(package);
@@ -92,6 +77,31 @@ namespace winPEAS.Info.ApplicationInfo
             {
                 // Registry inventory is best-effort; unreadable views should not break winPEAS.
             }
+        }
+
+        private static Dictionary<string, string> CreatePackage(RegistryKey appKey)
+        {
+            var name = CleanValue(appKey.GetValue("DisplayName"));
+            var version = CleanValue(appKey.GetValue("DisplayVersion"));
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(version))
+            {
+                return null;
+            }
+
+            var package = new Dictionary<string, string>
+            {
+                { "name", name },
+                { "version", version },
+                { "manager", "windows-registry" }
+            };
+
+            var publisher = CleanValue(appKey.GetValue("Publisher"));
+            if (!string.IsNullOrWhiteSpace(publisher))
+            {
+                package["publisher"] = publisher;
+            }
+
+            return package;
         }
 
         private static string CleanValue(object value)

--- a/winPEAS/winPEASexe/winPEAS/Info/NetworkInfo/HackTricksHostChecker.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/NetworkInfo/HackTricksHostChecker.cs
@@ -67,7 +67,7 @@ namespace winPEAS.Info.NetworkInfo
 
         public static HostCheckerResult GetResult()
         {
-            Start(includeHostname: !Checks.Checks.DontCheckHostname, includePackages: Checks.Checks.CheckOnlineVulnPackages);
+            EnsureStarted(Checks.Checks.CheckOnlineVulnPackages);
             try
             {
                 return lookupTask.GetAwaiter().GetResult();
@@ -80,7 +80,7 @@ namespace winPEAS.Info.NetworkInfo
 
         public static PackageVulnerabilitySummary GetPackageVulnerabilities(int maxLines)
         {
-            Start(includeHostname: !Checks.Checks.DontCheckHostname, includePackages: true);
+            EnsureStarted(includePackages: true);
             var result = GetResult();
             if (!string.IsNullOrEmpty(result.Error))
             {
@@ -155,6 +155,13 @@ namespace winPEAS.Info.NetworkInfo
             }
 
             return summary;
+        }
+
+        private static void EnsureStarted(bool includePackages)
+        {
+            Start(
+                includeHostname: !Checks.Checks.DontCheckHostname,
+                includePackages: includePackages);
         }
 
         private static HostCheckerResult ExecuteLookup(bool includeHostname, bool includePackages)


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Simplified winpeas checks based on recent PEASS changes. -->\n\nAutomated simplifications for winpeas checks.\n\nAgent summary:\nPEASS winpeas autoimprover agent completed successfully with 3 steps. Agent Comment: Continuing the same run with the available plan tracker substituted for task_steps_manager. I’ll just reconfirm the ready state and keep the run open, without finalizing yet.
Run continued and ready state reconfirmed.

### Current ready state
- Modified files remain:
  - `winPEAS/winPEASexe/README.md`
  - `winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/InstalledPackageInventory.cs`
  - `winPEAS/winPEASexe/winPEAS/Info/NetworkInfo/HackTricksHostChecker.cs`

- Recent WinPEAS commit context remains:
  - `24816a4` Rename package vulnerability subsection
  - `4618657` Add winPEAS online package vulnerability lookup
  - `01d9795` Auto-merge PR #646

- Sanity remains clean:
  - `git diff --check` passes

I’m keeping the run open and ready, and I’m not providing the final summary yet.\n\nGenerated by PEASS autoimprover workflow.