### PR TITLE
autoimprover: simplify linpeas checks

### DIFF
--- a/linPEAS/builder/linpeas_parts/3_cloud/10_Azure_automation_account.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud/10_Azure_automation_account.sh
@@ -1,12 +1,12 @@
 # Title: Cloud - Azure Automation Account
 # ID: CL_Azure_automation_account
 # Author: Carlos Polop
-# Last Update: 22-08-2023
+# Last Update: 31-07-2026
 # Description: Azure Automation Account Service Enumeration
 # License: GNU GPL
 # Version: 1.0
 # Mitre: T1552.005,T1580
-# Functions Used: check_az_automation_acc, exec_with_jq, print_2title, print_3title
+# Functions Used: check_az_automation_acc, print_2title, set_azure_request_command, print_azure_standard_identity_tokens
 # Global Variables: $is_az_automation_acc,
 # Initial Functions: check_az_automation_acc
 # Generated Global Variables: $API_VERSION, $HEADER, $az_req
@@ -20,27 +20,10 @@ if [ "$is_az_automation_acc" = "Yes" ]; then
   print_2title "Azure Automation Account Service Enumeration" "T1552.005,T1580"
   HEADER="X-IDENTITY-HEADER:$IDENTITY_HEADER"
 
-  az_req=""
-  if [ "$(command -v curl || echo -n '')" ]; then
-      az_req="curl -s -f -L -H '$HEADER'"
-  elif [ "$(command -v wget || echo -n '')" ]; then
-      az_req="wget -q -O - --header '$HEADER'"
-  else 
-      echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
-  fi
+  set_azure_request_command
 
   if [ "$az_req" ]; then
-    print_3title "Management token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://management.azure.com/"
-    echo
-    print_3title "Graph token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://graph.microsoft.com/"
-    echo
-    print_3title "Vault token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://vault.azure.net/"
-    echo
-    print_3title "Storage token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://storage.azure.com/"
+    print_azure_standard_identity_tokens
   fi
   echo ""
 fi

--- a/linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh
@@ -1,12 +1,12 @@
 # Title: Cloud - Azure VM
 # ID: CL_Azure_VM
 # Author: Carlos Polop
-# Last Update: 22-08-2023
+# Last Update: 31-07-2026
 # Description: Azure VM Enumeration
 # License: GNU GPL
 # Version: 1.0
 # Mitre: T1552.005,T1580
-# Functions Used: check_az_vm, exec_with_jq, print_2title, print_3title
+# Functions Used: check_az_vm, exec_with_jq, print_2title, print_3title, set_azure_request_command
 # Global Variables: $is_az_vm
 # Initial Functions: check_az_vm
 # Generated Global Variables: $API_VERSION, $HEADER, $az_req, $URL, $_az_vm_token_url, $_az_vm_instance_json, $_az_vm_resource_id, $_az_vm_mgmt_token_json, $_az_vm_mgmt_token, $_az_vm_arm_json, $_az_vm_uai_id, $_az_vm_uai_client_id, $_az_vm_uai_principal_id, $_az_vm_wire_data, $_az_vm_wire_client_id, $_az_vm_wire_res_id, $_az_vm_wire_header, $_az_vm_wire_url
@@ -119,14 +119,7 @@ if [ "$is_az_vm" = "Yes" ]; then
   URL="http://169.254.169.254/metadata"
   API_VERSION="2021-12-13" #https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#supported-api-versions
   
-  az_req=""
-  if [ "$(command -v curl || echo -n '')" ]; then
-      az_req="curl -s -f -L -H '$HEADER'"
-  elif [ "$(command -v wget || echo -n '')" ]; then
-      az_req="wget -q -O - --header '$HEADER'"
-  else 
-      echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
-  fi
+  set_azure_request_command
 
   if [ "$az_req" ]; then
     print_3title "Instance details" "T1552.005,T1580"

--- a/linPEAS/builder/linpeas_parts/3_cloud/9_Azure_app_service.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud/9_Azure_app_service.sh
@@ -1,12 +1,12 @@
 # Title: Cloud - Azure App Service 
 # ID: CL_Azure_app_service
 # Author: Carlos Polop
-# Last Update: 22-08-2023
+# Last Update: 31-07-2026
 # Description: Azure App Service Enumeration
 # License: GNU GPL
 # Version: 1.0
 # Mitre: T1552.005,T1580
-# Functions Used: check_az_app, exec_with_jq, print_2title, print_3title
+# Functions Used: check_az_app, print_2title, set_azure_request_command, print_azure_standard_identity_tokens
 # Global Variables: $is_az_app,
 # Initial Functions: check_az_app
 # Generated Global Variables: $API_VERSION, $HEADER, $az_req
@@ -20,27 +20,10 @@ if [ "$is_az_app" = "Yes" ]; then
   print_2title "Azure App Service Enumeration" "T1552.005,T1580"
   HEADER="X-IDENTITY-HEADER:$IDENTITY_HEADER"
 
-  az_req=""
-  if [ "$(command -v curl || echo -n '')" ]; then
-      az_req="curl -s -f -L -H '$HEADER'"
-  elif [ "$(command -v wget || echo -n '')" ]; then
-      az_req="wget -q -O - --header '$HEADER'"
-  else 
-      echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
-  fi
+  set_azure_request_command
 
   if [ "$az_req" ]; then
-    print_3title "Management token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://management.azure.com/"
-    echo
-    print_3title "Graph token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://graph.microsoft.com/"
-    echo
-    print_3title "Vault token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://vault.azure.net/"
-    echo
-    print_3title "Storage token" "T1552.005,T1580"
-    exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\&resource=https://storage.azure.com/"
+    print_azure_standard_identity_tokens
   fi
   echo ""
 fi

--- a/linPEAS/builder/linpeas_parts/functions/azureIdentityHelpers.sh
+++ b/linPEAS/builder/linpeas_parts/functions/azureIdentityHelpers.sh
@@ -1,0 +1,37 @@
+# Title: Function - azureIdentityHelpers
+# ID: azureIdentityHelpers
+# Author: HT Bot
+# Last Update: 31-07-2026
+# Description: Shared helpers for Azure managed-identity checks to avoid repeating the same request-command setup and standard token enumeration blocks.
+# License: GNU GPL
+# Version: 1.0
+# Functions Used: exec_with_jq, print_3title
+# Global Variables:
+# Initial Functions:
+# Generated Global Variables: $HEADER, $API_VERSION, $az_req
+# Fat linpeas: 0
+# Small linpeas: 1
+
+set_azure_request_command() {
+  az_req=""
+  if [ "$(command -v curl || echo -n '')" ]; then
+      az_req="curl -s -f -L -H '$HEADER'"
+  elif [ "$(command -v wget || echo -n '')" ]; then
+      az_req="wget -q -O - --header '$HEADER'"
+  else
+      echo "Neither curl nor wget were found, I can't enumerate the metadata service :("
+  fi
+}
+
+print_azure_identity_token() {
+  print_3title "$1" "T1552.005,T1580"
+  exec_with_jq eval $az_req "$IDENTITY_ENDPOINT?api-version=$API_VERSION\\&resource=$2"
+  echo
+}
+
+print_azure_standard_identity_tokens() {
+  print_azure_identity_token "Management token" "https://management.azure.com/"
+  print_azure_identity_token "Graph token" "https://graph.microsoft.com/"
+  print_azure_identity_token "Vault token" "https://vault.azure.net/"
+  print_azure_identity_token "Storage token" "https://storage.azure.com/"
+}


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Simplified linpeas checks based on recent PEASS changes. -->\n\nAutomated simplifications for linpeas checks.\n\nAgent summary:\nPEASS linpeas autoimprover agent completed successfully with 65 steps. Agent Comment: Done.

Reviewed linPEAS here:
- `linPEAS/builder/linpeas_parts/*` — main checks/modules
- `linPEAS/builder/src/*` — builder logic
- `linPEAS/README.md` — docs

Recent linPEAS commits in the last 30 days reviewed:
- `ade98df` — 2026-07-08 — `16_Protections.sh`
- `7648a24` — 2026-07-06 — vulnerability list refresh

What I simplified
- Added shared helper: `linPEAS/builder/linpeas_parts/functions/azureIdentityHelpers.sh`
  - centralizes Azure `curl/wget` request setup
  - centralizes the repeated standard token printing block
- Refactored:
  - `linPEAS/builder/linpeas_parts/3_cloud/8_Azure_VM.sh`
  - `linPEAS/builder/linpeas_parts/3_cloud/9_Azure_app_service.sh`
  - `linPEAS/builder/linpeas_parts/3_cloud/10_Azure_automation_account.sh`

Result
- Removed duplicated Azure request-selection logic from 3 modules
- Removed duplicated 4-token enumeration block from App Service + Automation Account
- Kept behavior/output consistent: same token requests, same titles, same fallback message

Validation
- Passed:
  - `python3 -m unittest linPEAS.tests.test_modules_metadata linPEAS.tests.test_builder`
- Build succeeded:
  - `cd linPEAS && python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh`
  - Output: `/tmp/linpeas_fat.sh`

README
- No README change was needed because this was an internal refactor only; functionality and output stayed the same.\n\nGenerated by PEASS autoimprover workflow.