### PR TITLE
feat(linpeas): expand doas security checks

### DIFF
--- a/linPEAS/builder/linpeas_parts/6_users_information/9_Doas.sh
+++ b/linPEAS/builder/linpeas_parts/6_users_information/9_Doas.sh
@@ -1,56 +1,252 @@
 # Title: Users Information - Doas
 # ID: UG_Doas
 # Author: Carlos Polop
-# Last Update: 22-08-2023
-# Description: Check doas configuration and permissions for privilege escalation
+# Last Update: 11-08-2026
+# Description: Check doas/OpenDoas configuration, effective rules, binary permissions, and known vulnerable versions.
+#   Detects unrestricted and nopass root rules, GTFOBins-capable commands (including the HTB Soccer dstat path), dangerous environment preservation, writable configuration paths, and applicable CVEs.
 # License: GNU GPL
-# Version: 1.0
+# Version: 1.1
 # Mitre: T1548.003
-# Functions Used: echo_not_found, print_2title, print_info
-# Global Variables: $DEBUG, $nosh_usrs, $sh_usrs, $USER
+# Functions Used: doas_check_command, doas_command_is_dangerous, doas_config_syntax_valid, doas_extract_upstream_version, doas_get_package_details, doas_read_rules, doas_rule_applies_to_current_user, doas_rule_command, doas_rule_has_dangerous_environment, doas_rule_has_option, doas_rule_targets_root, doas_version_ge, doas_version_le, doas_version_lt, echo_not_found, print_2title, print_3title, print_info
+# Global Variables: $doas_package_full_version, $doas_package_homepage, $doas_package_implementation, $doas_package_manager, $doas_package_name
 # Initial Functions:
-# Generated Global Variables: $doas_dir_name, $doas_bin, $conf_file
+# Generated Global Variables: $conf_file, $doas_active_rules, $doas_bin, $doas_bin_mode, $doas_bin_owner, $doas_bin_trusted, $doas_conf_candidates, $doas_conf_dir, $doas_conf_dir_mode, $doas_conf_found, $doas_conf_mode, $doas_conf_owner, $doas_conf_trusted, $doas_current_gids, $doas_current_groups, $doas_current_uid, $doas_current_user, $doas_package_label, $doas_rule_applies, $doas_rule_cmd_value, $doas_rule_dangerous, $doas_rule_env, $doas_rule_line, $doas_rule_nopass, $doas_rule_number, $doas_rule_root, $doas_rule_unrestricted, $doas_seen_configs, $doas_seen_test_commands, $doas_strings_conf, $doas_test_cmd, $doas_test_commands, $doas_check_output, $doas_tiocsti, $doas_upstream_version
 # Fat linpeas: 0
 # Small linpeas: 1
 
 
-if [ -f "/etc/doas.conf" ] || [ -f "/usr/local/etc/doas.conf" ] || [ "$DEBUG" ]; then
-  print_2title "Doas Configuration" "T1548.003"
+doas_bin="$(command -v doas 2>/dev/null)"
+doas_current_user="$(id -un 2>/dev/null)"
+doas_current_uid="$(id -u 2>/dev/null)"
+doas_current_groups="$(id -Gn 2>/dev/null)"
+doas_current_gids="$(id -G 2>/dev/null)"
+doas_bin_trusted="no"
+
+doas_conf_candidates="/etc/doas.conf
+/usr/local/etc/doas.conf
+/opt/local/etc/doas.conf
+/usr/pkg/etc/doas.conf"
+
+if [ -n "$doas_bin" ]; then
+  doas_conf_candidates="$doas_conf_candidates
+$(dirname "$doas_bin")/doas.conf
+$(dirname "$doas_bin")/../etc/doas.conf
+$(dirname "$doas_bin")/etc/doas.conf"
+  if command -v strings >/dev/null 2>&1; then
+    doas_strings_conf="$(strings "$doas_bin" 2>/dev/null | grep -E '^/[^[:space:]]*/doas\.conf$' | head -n 10)"
+    [ -n "$doas_strings_conf" ] && doas_conf_candidates="$doas_conf_candidates
+$doas_strings_conf"
+  fi
+fi
+
+doas_conf_found="no"
+for conf_file in /etc/doas.conf /usr/local/etc/doas.conf /opt/local/etc/doas.conf /usr/pkg/etc/doas.conf; do
+  [ -e "$conf_file" ] && doas_conf_found="yes"
+done
+
+if [ -n "$doas_bin" ] || [ "$doas_conf_found" = "yes" ]; then
+  print_2title "Doas/OpenDoas configuration and vulnerabilities" "T1548.003"
   print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/index.html#doas"
 
-  # Find doas binary and its config locations
-  doas_bin=$(command -v doas 2>/dev/null)
   if [ -n "$doas_bin" ]; then
-    doas_dir_name=$(dirname "$doas_bin")
+    print_3title "Doas binary and version" "T1548.003"
+    # -L makes permission checks describe the executable target, not a package-manager symlink.
+    doas_bin_owner="$(ls -ldLn "$doas_bin" 2>/dev/null | awk '{print $3}')"
+    doas_bin_mode="$(ls -ldL "$doas_bin" 2>/dev/null | awk '{print $1}')"
     echo "Doas binary found at: $doas_bin" | sed -${E} "s,.*,${SED_LIGHT_CYAN},g"
-    
-    # Check doas binary permissions
-    if [ -u "$doas_bin" ]; then
-      echo "Doas binary has SUID bit set!" | sed -${E} "s,.*,${SED_RED},g"
+    ls -ld "$doas_bin" 2>/dev/null
+
+    doas_bin_trusted="yes"
+    if [ "$doas_bin_owner" != "0" ]; then
+      echo "WARNING: doas is not owned by root (owner UID: ${doas_bin_owner:-unknown})" | sed -${E} "s,.*,${SED_RED},g"
+      doas_bin_trusted="no"
     fi
-    ls -l "$doas_bin" 2>/dev/null | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+    if [ -u "$doas_bin" ]; then
+      echo "Doas has the expected SUID bit set (normal for a privilege-delegation binary)" | sed -${E} "s,.*,${SED_GREEN},g"
+    else
+      echo "Doas does not have its usual SUID bit; verify how privileges are granted" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+      doas_bin_trusted="no"
+    fi
+    if { [ "$doas_current_uid" != "0" ] && [ -w "$doas_bin" ]; } || printf "%s" "$doas_bin_mode" | cut -c6,9 | grep -q w; then
+      echo "CRITICAL: doas is writable by a non-root context or by group/other" | sed -${E} "s,.*,${SED_RED},g"
+      doas_bin_trusted="no"
+    fi
+
+    doas_get_package_details "$doas_bin"
+    doas_upstream_version="$(doas_extract_upstream_version "$doas_package_full_version")"
+    if [ -n "$doas_package_full_version" ]; then
+      doas_package_label="$doas_package_name $doas_package_full_version (${doas_package_manager:-unknown manager}, implementation: $doas_package_implementation)"
+      echo "Package: $doas_package_label"
+      [ -n "$doas_package_homepage" ] && echo "Homepage: $doas_package_homepage"
+
+      if { [ "$doas_package_implementation" = "opendoas" ] || [ "$doas_package_implementation" = "unknown" ]; } && \
+         [ -n "$doas_upstream_version" ] && doas_version_ge "$doas_upstream_version" "6.6" && doas_version_lt "$doas_upstream_version" "6.8.1"; then
+        echo "Potentially vulnerable to CVE-2019-25016: OpenDoas 6.6 through 6.8 may inherit an attacker-controlled PATH for unrestricted rules (verify distro backports)" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+      fi
+
+      if [ "$doas_package_implementation" = "slicer69" ] && [ -n "$doas_upstream_version" ] && doas_version_lt "$doas_upstream_version" "6.2"; then
+        echo "Potentially vulnerable to CVE-2019-15900 and CVE-2019-15901: slicer69/doas before 6.2 can mishandle identities/groups on non-OpenBSD platforms" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+      elif [ "$doas_package_implementation" = "unknown" ] && [ -n "$doas_upstream_version" ] && doas_version_lt "$doas_upstream_version" "6.2"; then
+        echo "Old doas version detected; if this is the slicer69 portable implementation, review CVE-2019-15900 and CVE-2019-15901" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+      fi
+
+      if [ "$(uname -s 2>/dev/null)" = "Linux" ] && \
+         { [ "$doas_package_implementation" = "opendoas" ] || [ "$doas_package_implementation" = "unknown" ]; } && \
+         [ -n "$doas_upstream_version" ] && doas_version_le "$doas_upstream_version" "6.8.2"; then
+        if [ -r /proc/sys/dev/tty/legacy_tiocsti ]; then
+          doas_tiocsti="$(cat /proc/sys/dev/tty/legacy_tiocsti 2>/dev/null)"
+          if [ "$doas_tiocsti" = "1" ]; then
+            echo "Potentially vulnerable to CVE-2023-28339: OpenDoas <=6.8.2 shares the terminal and legacy TIOCSTI is enabled" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+          else
+            echo "CVE-2023-28339 TIOCSTI path appears mitigated (dev.tty.legacy_tiocsti=$doas_tiocsti)" | sed -${E} "s,.*,${SED_GREEN},g"
+          fi
+        else
+          echo "OpenDoas <=6.8.2 detected; review CVE-2023-28339 because the kernel TIOCSTI mitigation state could not be read" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+        fi
+      fi
+    else
+      echo "Could not determine the installed doas package/version; check vendor advisories manually" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+    fi
+  else
+    echo_not_found "doas"
   fi
 
-  # Check all possible doas.conf locations
-  echo -e "\nChecking doas.conf files:" | sed -${E} "s,.*,${SED_LIGHT_CYAN},g"
-  for conf_file in "/etc/doas.conf" "$doas_dir_name/doas.conf" "$doas_dir_name/../etc/doas.conf" "$doas_dir_name/etc/doas.conf" "/usr/local/etc/doas.conf"; do
-    if [ -f "$conf_file" ]; then
-      echo "Found: $conf_file" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
-      if [ -w "$conf_file" ]; then
-        echo "WARNING: $conf_file is writable!" | sed -${E} "s,.*,${SED_RED},g"
-      fi
-      cat "$conf_file" 2>/dev/null | sed -${E} "s,$sh_usrs,${SED_RED},g" | sed "s,root,${SED_RED},g" | sed "s,nopass,${SED_RED},g" | sed -${E} "s,$nosh_usrs,${SED_BLUE},g" | sed "s,$USER,${SED_RED_YELLOW},g"
-    fi
-  done
+  echo ""
+  print_3title "Doas configuration rules" "T1548.003"
+  doas_conf_found="no"
+  doas_seen_configs="|"
+  while IFS= read -r conf_file; do
+    [ -n "$conf_file" ] || continue
+    case "$doas_seen_configs" in *"|$conf_file|"*) continue ;; esac
+    doas_seen_configs="$doas_seen_configs$conf_file|"
+    [ -e "$conf_file" ] || continue
+    doas_conf_found="yes"
 
-  # Check if doas is working
-  if [ -n "$doas_bin" ]; then
-    echo -e "\nTesting doas:" | sed -${E} "s,.*,${SED_LIGHT_CYAN},g"
-    if $doas_bin -l 2>/dev/null; then
-      echo "doas -l command works!" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+    # Follow the final symlink for ownership/mode checks, but still report the indirection below.
+    doas_conf_owner="$(ls -ldLn "$conf_file" 2>/dev/null | awk '{print $3}')"
+    doas_conf_mode="$(ls -ldL "$conf_file" 2>/dev/null | awk '{print $1}')"
+    doas_conf_dir="$(dirname "$conf_file")"
+    doas_conf_dir_mode="$(ls -ld "$doas_conf_dir" 2>/dev/null | awk '{print $1}')"
+    echo "Found: $conf_file ($doas_conf_mode owner UID ${doas_conf_owner:-unknown})" | sed -${E} "s,.*,${SED_LIGHT_CYAN},g"
+
+    doas_conf_trusted="yes"
+    if [ -L "$conf_file" ]; then
+      echo "WARNING: $conf_file is a symbolic link; verify its target and ownership" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
     fi
+    if [ "$doas_conf_owner" != "0" ]; then
+      echo "CRITICAL: $conf_file is not owned by root" | sed -${E} "s,.*,${SED_RED},g"
+      doas_conf_trusted="no"
+    fi
+    if { [ "$doas_current_uid" != "0" ] && [ -w "$conf_file" ]; } || printf "%s" "$doas_conf_mode" | cut -c6,9 | grep -q w; then
+      echo "CRITICAL: $conf_file is writable by the current user, group, or other users" | sed -${E} "s,.*,${SED_RED},g"
+      doas_conf_trusted="no"
+    fi
+    if { [ "$doas_current_uid" != "0" ] && [ -w "$doas_conf_dir" ]; } || printf "%s" "$doas_conf_dir_mode" | cut -c6,9 | grep -q w; then
+      echo "CRITICAL: configuration directory $doas_conf_dir is writable; doas.conf may be replaceable" | sed -${E} "s,.*,${SED_RED},g"
+      doas_conf_trusted="no"
+    fi
+
+    if [ -r "$conf_file" ]; then
+      doas_active_rules="$(doas_read_rules "$conf_file")"
+      if [ -z "$doas_active_rules" ]; then
+        echo "No active permit/deny rules found in $conf_file"
+      else
+        while IFS="	" read -r doas_rule_number doas_rule_line; do
+          [ -n "$doas_rule_line" ] || continue
+          doas_rule_applies="no"
+          doas_rule_root="no"
+          doas_rule_nopass="no"
+          doas_rule_unrestricted="no"
+          doas_rule_dangerous="no"
+          doas_rule_env="no"
+          doas_rule_cmd_value="$(doas_rule_command "$doas_rule_line")"
+          doas_rule_applies_to_current_user "$doas_rule_line" && doas_rule_applies="yes"
+          doas_rule_targets_root "$doas_rule_line" && doas_rule_root="yes"
+          doas_rule_has_option "$doas_rule_line" nopass && doas_rule_nopass="yes"
+          [ -z "$doas_rule_cmd_value" ] && doas_rule_unrestricted="yes"
+          [ -n "$doas_rule_cmd_value" ] && doas_command_is_dangerous "$doas_rule_cmd_value" && doas_rule_dangerous="yes"
+          doas_rule_has_dangerous_environment "$doas_rule_line" && doas_rule_env="yes"
+
+          if printf "%s" "$doas_rule_line" | grep -q '^deny'; then
+            echo "  $conf_file:$doas_rule_number $doas_rule_line"
+            continue
+          fi
+
+          if [ "$doas_rule_applies" = "yes" ] && [ "$doas_rule_root" = "yes" ]; then
+            echo "  $conf_file:$doas_rule_number $doas_rule_line" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+            if [ "$doas_rule_unrestricted" = "yes" ] && [ "$doas_rule_nopass" = "yes" ]; then
+              echo "POTENTIAL: a matching permit rule allows arbitrary root commands without a password; a later rule may override it" | sed -${E} "s,.*,${SED_RED},g"
+            elif [ "$doas_rule_unrestricted" = "yes" ]; then
+              echo "POTENTIAL: a matching permit rule allows arbitrary root commands after authentication; a later rule may override it" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+            elif [ "$doas_rule_dangerous" = "yes" ] && [ "$doas_rule_nopass" = "yes" ]; then
+              echo "POTENTIAL: a matching permit rule allows GTFOBins-capable command $doas_rule_cmd_value as root without a password; a later rule may override it" | sed -${E} "s,.*,${SED_RED},g"
+              if [ "${doas_rule_cmd_value##*/}" = "dstat" ]; then
+                echo "This is the HTB Soccer privilege-escalation pattern: a user-controlled dstat plugin can execute as root" | sed -${E} "s,.*,${SED_RED},g"
+              fi
+            elif [ "$doas_rule_dangerous" = "yes" ]; then
+              echo "POTENTIAL: a matching permit rule allows GTFOBins-capable command $doas_rule_cmd_value as root after authentication; a later rule may override it" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+            elif [ "$doas_rule_nopass" = "yes" ]; then
+              echo "POTENTIAL: a matching permit rule allows $doas_rule_cmd_value as root without a password; inspect command-specific escapes and later rules" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+            fi
+            if [ "$doas_rule_env" = "yes" ]; then
+              echo "Dangerous environment preservation is enabled for an applicable root rule (keepenv or sensitive setenv variable)" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+            fi
+          elif [ "$doas_rule_root" = "yes" ] && { [ "$doas_rule_nopass" = "yes" ] || [ "$doas_rule_unrestricted" = "yes" ] || [ "$doas_rule_dangerous" = "yes" ]; }; then
+            echo "  $conf_file:$doas_rule_number $doas_rule_line" | sed -${E} "s,.*,${SED_LIGHT_CYAN},g"
+          else
+            echo "  $conf_file:$doas_rule_number $doas_rule_line"
+          fi
+        done <<EOF
+$doas_active_rules
+EOF
+      fi
+    else
+      echo "Cannot read $conf_file directly; attempting safe effective-rule checks with doas -C"
+      doas_active_rules=""
+    fi
+
+    if [ -n "$doas_bin" ] && [ "$doas_bin_trusted" = "yes" ] && [ "$doas_conf_trusted" = "yes" ]; then
+      if doas_config_syntax_valid "$doas_bin" "$conf_file"; then
+        doas_test_commands="/bin/sh
+/bin/bash
+/usr/bin/env
+/usr/bin/dstat"
+        while IFS="	" read -r doas_rule_number doas_rule_line; do
+          doas_rule_cmd_value="$(doas_rule_command "$doas_rule_line")"
+          [ -n "$doas_rule_cmd_value" ] && doas_test_commands="$doas_test_commands
+$doas_rule_cmd_value"
+        done <<EOF
+$doas_active_rules
+EOF
+        doas_seen_test_commands="|"
+        while IFS= read -r doas_test_cmd; do
+          [ -n "$doas_test_cmd" ] || continue
+          case "$doas_seen_test_commands" in *"|$doas_test_cmd|"*) continue ;; esac
+          doas_seen_test_commands="$doas_seen_test_commands$doas_test_cmd|"
+          doas_check_output="$(doas_check_command "$doas_bin" "$conf_file" "$doas_test_cmd")"
+          case "$doas_check_output" in
+            "permit nopass"*)
+              echo "EFFECTIVE RULE: current user may run $doas_test_cmd as root without a password ($doas_check_output)" | sed -${E} "s,.*,${SED_RED},g"
+              ;;
+            permit*)
+              echo "Effective rule: current user may run $doas_test_cmd as root after authentication ($doas_check_output)" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+              ;;
+          esac
+        done <<EOF
+$doas_test_commands
+EOF
+      else
+        echo "doas rejected or could not validate $conf_file with -C; inspect its syntax and security properties" | sed -${E} "s,.*,${SED_RED_YELLOW},g"
+      fi
+    fi
+  done <<EOF
+$doas_conf_candidates
+EOF
+
+  if [ "$doas_conf_found" = "no" ]; then
+    echo_not_found "doas.conf"
   fi
 else
-  echo_not_found "doas.conf"
+  echo_not_found "doas"
 fi
 echo ""

--- a/linPEAS/builder/linpeas_parts/functions/checkDoas.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkDoas.sh
@@ -1,0 +1,279 @@
+# Title: Function - checkDoas
+# ID: checkDoas
+# Author: Carlos Polop
+# Last Update: 11-08-2026
+# Description: Helpers for detecting dangerous doas rules, package versions, and effective permissions without executing privileged commands.
+# License: GNU GPL
+# Version: 1.0
+# Functions Used:
+# Global Variables: $TIMEOUT, $doas_current_gids, $doas_current_groups, $doas_current_uid, $doas_current_user, $sudoVB1, $sudoVB2
+# Initial Functions:
+# Generated Global Variables: $doas_candidate, $doas_candidate_version, $doas_homepage_lower, $doas_package_full_version, $doas_package_homepage, $doas_package_implementation, $doas_package_line, $doas_package_manager, $doas_package_name, $doas_package_source, $doas_rule_cmd, $doas_rule_identity_value
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+doas_extract_upstream_version() {
+  printf "%s\n" "$1" | grep -oE '[0-9]+(\.[0-9]+){1,2}' | head -n 1
+}
+
+doas_version_ge() {
+  awk -v left="$1" -v right="$2" 'BEGIN {
+    left_n = split(left, left_v, ".")
+    right_n = split(right, right_v, ".")
+    max_n = left_n > right_n ? left_n : right_n
+    for (i = 1; i <= max_n; i++) {
+      left_i = (i <= left_n ? left_v[i] : 0) + 0
+      right_i = (i <= right_n ? right_v[i] : 0) + 0
+      if (left_i > right_i) exit 0
+      if (left_i < right_i) exit 1
+    }
+    exit 0
+  }'
+}
+
+doas_version_lt() {
+  if doas_version_ge "$1" "$2"; then
+    return 1
+  fi
+  return 0
+}
+
+doas_version_le() {
+  if doas_version_lt "$2" "$1"; then
+    return 1
+  fi
+  return 0
+}
+
+doas_read_rules() {
+  awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    {
+      source = $0
+      output = ""
+      quoted = 0
+      escaped = 0
+      for (i = 1; i <= length(source); i++) {
+        char = substr(source, i, 1)
+        if (char == "#" && !quoted) break
+        output = output char
+        if (char == "\"" && !escaped) quoted = !quoted
+        if (char == "\\" && !escaped) escaped = 1
+        else escaped = 0
+      }
+      output = trim(output)
+      if (output ~ /^(permit|deny)([[:space:]]|$)/)
+        printf "%d\t%s\n", NR, output
+    }
+  ' "$1" 2>/dev/null
+}
+
+doas_rule_identity() {
+  printf "%s\n" "$1" | awk '
+    {
+      in_setenv = 0
+      for (i = 2; i <= NF; i++) {
+        token = $i
+        if (in_setenv) {
+          if (token ~ /}/) in_setenv = 0
+          continue
+        }
+        if (token == "setenv") {
+          in_setenv = 1
+          continue
+        }
+        if (token == "nopass" || token == "nolog" || token == "persist" || token == "keepenv")
+          continue
+        gsub(/^"|"$/, "", token)
+        print token
+        exit
+      }
+    }
+  '
+}
+
+doas_rule_has_option() {
+  printf "%s\n" "$1" | awk -v wanted="$2" '
+    {
+      in_setenv = 0
+      for (i = 2; i <= NF; i++) {
+        token = $i
+        if (in_setenv) {
+          if (token ~ /}/) in_setenv = 0
+          continue
+        }
+        if (token == "setenv") {
+          if (wanted == token) exit 0
+          in_setenv = 1
+          continue
+        }
+        if (token == "nopass" || token == "nolog" || token == "persist" || token == "keepenv") {
+          if (wanted == token) exit 0
+          continue
+        }
+        exit 1
+      }
+      exit 1
+    }
+  '
+}
+
+doas_rule_has_dangerous_environment() {
+  if doas_rule_has_option "$1" keepenv; then
+    return 0
+  fi
+  printf "%s\n" "$1" | grep -Eq '(^|[[:space:]{])(setenv[[:space:]]*\{[^}]*[[:space:]])?(PATH|LD_PRELOAD|LD_LIBRARY_PATH|BASH_ENV|ENV|PYTHONPATH|PERL5LIB|RUBYLIB)([=[:space:]}]|$)'
+}
+
+doas_rule_command() {
+  printf "%s\n" "$1" | awk '
+    {
+      for (i = 1; i < NF; i++) {
+        if ($i == "cmd") {
+          command = $(i + 1)
+          gsub(/^"|"$/, "", command)
+          print command
+          exit
+        }
+      }
+    }
+  '
+}
+
+doas_rule_targets_root() {
+  printf "%s\n" "$1" | awk '
+    {
+      for (i = 1; i < NF; i++) {
+        if ($i == "as") {
+          target = $(i + 1)
+          gsub(/^"|"$/, "", target)
+          exit(target == "root" || target == "0" || target == "#0" ? 0 : 1)
+        }
+      }
+      exit 0
+    }
+  '
+}
+
+doas_rule_applies_to_current_user() {
+  doas_rule_identity_value="$(doas_rule_identity "$1")"
+  case "$doas_rule_identity_value" in
+    "$doas_current_user"|"$doas_current_uid"|"#$doas_current_uid") return 0 ;;
+  esac
+
+  case "$doas_rule_identity_value" in
+    :*)
+      doas_rule_identity_value="${doas_rule_identity_value#:}"
+      for doas_candidate in $doas_current_groups $doas_current_gids; do
+        if [ "$doas_candidate" = "$doas_rule_identity_value" ] || [ "#$doas_candidate" = "$doas_rule_identity_value" ]; then
+          return 0
+        fi
+      done
+      ;;
+  esac
+  return 1
+}
+
+doas_command_is_dangerous() {
+  doas_rule_cmd="$1"
+  doas_rule_cmd="${doas_rule_cmd##*/}"
+  case "$doas_rule_cmd" in
+    ash|awk|bash|busybox|csh|dash|dstat|ed|env|expect|find|fish|gdb|git|ionice|jrunscript|ksh|less|lua|make|more|mv|nano|nawk|nc|ncat|nice|node|nvim|perl|php|python|python2|python3|rake|rlwrap|ruby|run-parts|rvim|sed|sh|socat|sqlite3|tar|tee|tclsh|vi|vim|watch|xargs|zsh)
+      return 0
+      ;;
+  esac
+
+  if [ -n "${sudoVB1:-}" ] && printf " %s\n" "$1" | grep -Eq "$sudoVB1" 2>/dev/null; then
+    return 0
+  fi
+  if [ -n "${sudoVB2:-}" ] && printf " %s\n" "$1" | grep -Eq "$sudoVB2" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+doas_get_package_details() {
+  doas_package_manager=""
+  doas_package_name=""
+  doas_package_full_version=""
+  doas_package_source=""
+  doas_package_homepage=""
+  doas_package_implementation="unknown"
+
+  if command -v dpkg-query >/dev/null 2>&1; then
+    doas_package_name="$(dpkg-query -S "$1" 2>/dev/null | head -n 1 | sed 's/: .*//' | cut -d: -f1)"
+    if [ -n "$doas_package_name" ]; then
+      doas_package_manager="dpkg"
+      doas_package_full_version="$(dpkg-query -W -f='$''{Version}\n' "$doas_package_name" 2>/dev/null | head -n 1)"
+      doas_package_source="$(dpkg-query -W -f='$''{source:Package}\n' "$doas_package_name" 2>/dev/null | head -n 1 | sed 's/^src://')"
+      doas_package_homepage="$(dpkg-query -W -f='$''{Homepage}\n' "$doas_package_name" 2>/dev/null | head -n 1)"
+    fi
+  elif command -v rpm >/dev/null 2>&1; then
+    doas_package_line="$(rpm -qf --qf '%{NAME}|%{VERSION}-%{RELEASE}|%{URL}\n' "$1" 2>/dev/null | head -n 1)"
+    if [ -n "$doas_package_line" ]; then
+      doas_package_manager="rpm"
+      doas_package_name="$(printf "%s" "$doas_package_line" | cut -d'|' -f1)"
+      doas_package_full_version="$(printf "%s" "$doas_package_line" | cut -d'|' -f2)"
+      doas_package_homepage="$(printf "%s" "$doas_package_line" | cut -d'|' -f3-)"
+    fi
+  elif command -v apk >/dev/null 2>&1; then
+    for doas_candidate in opendoas doas; do
+      doas_candidate_version="$(apk info -e -v "$doas_candidate" 2>/dev/null | head -n 1)"
+      if [ -n "$doas_candidate_version" ]; then
+        doas_package_manager="apk"
+        doas_package_name="$doas_candidate"
+        doas_package_full_version="${doas_candidate_version#${doas_candidate}-}"
+        doas_package_homepage="$(apk info -a "$doas_candidate" 2>/dev/null | sed -n 's/^webpage[[:space:]]*:[[:space:]]*//p' | head -n 1)"
+        break
+      fi
+    done
+  elif command -v pacman >/dev/null 2>&1; then
+    doas_package_line="$(pacman -Qo "$1" 2>/dev/null | head -n 1)"
+    doas_package_name="$(printf "%s\n" "$doas_package_line" | sed -nE 's/.* is owned by ([^ ]+) .*/\1/p')"
+    doas_package_full_version="$(printf "%s\n" "$doas_package_line" | sed -nE 's/.* is owned by [^ ]+ ([^ ]+).*/\1/p')"
+    if [ -n "$doas_package_name" ]; then
+      doas_package_manager="pacman"
+      doas_package_homepage="$(pacman -Qi "$doas_package_name" 2>/dev/null | sed -n 's/^URL[[:space:]]*:[[:space:]]*//p' | head -n 1)"
+    fi
+  elif command -v pkg >/dev/null 2>&1; then
+    doas_package_name="$(pkg which -q "$1" 2>/dev/null | head -n 1)"
+    if [ -n "$doas_package_name" ]; then
+      doas_package_manager="pkg"
+      doas_package_line="$(pkg query '%n|%v|%o|%w' "$doas_package_name" 2>/dev/null | head -n 1)"
+      doas_package_name="$(printf "%s" "$doas_package_line" | cut -d'|' -f1)"
+      doas_package_full_version="$(printf "%s" "$doas_package_line" | cut -d'|' -f2)"
+      doas_package_source="$(printf "%s" "$doas_package_line" | cut -d'|' -f3)"
+      doas_package_homepage="$(printf "%s" "$doas_package_line" | cut -d'|' -f4-)"
+    fi
+  fi
+
+  doas_homepage_lower="$(printf "%s" "$doas_package_homepage" | tr '[:upper:]' '[:lower:]')"
+  case "$doas_homepage_lower:$doas_package_source:$doas_package_name" in
+    *duncaen/opendoas*|*:opendoas:*|*:*:opendoas) doas_package_implementation="opendoas" ;;
+    *slicer69/doas*) doas_package_implementation="slicer69" ;;
+  esac
+  if [ "$(uname -s 2>/dev/null)" = "OpenBSD" ]; then
+    doas_package_implementation="openbsd"
+  fi
+}
+
+doas_config_syntax_valid() {
+  if [ -n "${TIMEOUT:-}" ]; then
+    "$TIMEOUT" 5 "$1" -C "$2" >/dev/null 2>&1
+  else
+    "$1" -C "$2" >/dev/null 2>&1
+  fi
+}
+
+doas_check_command() {
+  if [ -n "${TIMEOUT:-}" ]; then
+    "$TIMEOUT" 5 "$1" -C "$2" "$3" 2>/dev/null
+  else
+    "$1" -C "$2" "$3" 2>/dev/null
+  fi
+}

--- a/linPEAS/tests/test_doas.py
+++ b/linPEAS/tests/test_doas.py
@@ -1,0 +1,261 @@
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class DoasCheckTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[2]
+        cls.function_file = (
+            cls.repo_root
+            / "linPEAS"
+            / "builder"
+            / "linpeas_parts"
+            / "functions"
+            / "checkDoas.sh"
+        )
+        cls.module_file = (
+            cls.repo_root
+            / "linPEAS"
+            / "builder"
+            / "linpeas_parts"
+            / "6_users_information"
+            / "9_Doas.sh"
+        )
+
+    def _run_shell(self, body, env=None):
+        script = f". {shlex.quote(str(self.function_file))}\n{body}"
+        return subprocess.run(
+            ["sh", "-c", script],
+            cwd=str(self.repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_version_parsing_and_comparison(self):
+        result = self._run_shell(
+            """
+printf 'parsed=%s\n' "$(doas_extract_upstream_version '1:6.8.2-1ubuntu1')"
+doas_version_lt 6.8 6.8.1 && echo lt=yes
+doas_version_ge 6.8.1 6.8.1 && echo ge=yes
+doas_version_le 6.8.2 6.8.2 && echo le=yes
+! doas_version_lt 6.9 6.8.1 && echo newer=yes
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("parsed=6.8.2", result.stdout)
+        self.assertIn("lt=yes", result.stdout)
+        self.assertIn("ge=yes", result.stdout)
+        self.assertIn("le=yes", result.stdout)
+        self.assertIn("newer=yes", result.stdout)
+
+    def test_soccer_rule_matches_current_user_and_dstat(self):
+        result = self._run_shell(
+            """
+doas_current_user=player
+doas_current_uid=1000
+doas_current_groups='player users'
+doas_current_gids='1000 100'
+sudoVB1='dstat$'
+sudoVB2=''
+rule='permit nopass player as root cmd /usr/bin/dstat'
+printf 'identity=%s\n' "$(doas_rule_identity "$rule")"
+printf 'command=%s\n' "$(doas_rule_command "$rule")"
+doas_rule_applies_to_current_user "$rule" && echo applies=yes
+doas_rule_targets_root "$rule" && echo root=yes
+doas_rule_has_option "$rule" nopass && echo nopass=yes
+doas_command_is_dangerous "$(doas_rule_command "$rule")" && echo dangerous=yes
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("identity=player", result.stdout)
+        self.assertIn("command=/usr/bin/dstat", result.stdout)
+        self.assertIn("applies=yes", result.stdout)
+        self.assertIn("root=yes", result.stdout)
+        self.assertIn("nopass=yes", result.stdout)
+        self.assertIn("dangerous=yes", result.stdout)
+
+    def test_group_rule_and_setenv_options_are_parsed(self):
+        result = self._run_shell(
+            """
+doas_current_user=alice
+doas_current_uid=1001
+doas_current_groups='alice wheel'
+doas_current_gids='1001 10'
+rule='permit setenv { PATH=/tmp LD_PRELOAD } nopass :wheel as root cmd /usr/bin/env'
+printf 'identity=%s\n' "$(doas_rule_identity "$rule")"
+doas_rule_applies_to_current_user "$rule" && echo applies=yes
+doas_rule_has_option "$rule" setenv && echo setenv=yes
+doas_rule_has_dangerous_environment "$rule" && echo environment=dangerous
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("identity=:wheel", result.stdout)
+        self.assertIn("applies=yes", result.stdout)
+        self.assertIn("setenv=yes", result.stdout)
+        self.assertIn("environment=dangerous", result.stdout)
+
+    def test_rule_reader_ignores_comments_but_preserves_quoted_hashes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Path(tmpdir) / "doas.conf"
+            config.write_text(
+                "# ignored\n"
+                "permit nopass player as root cmd /usr/bin/dstat # Soccer\n"
+                'permit player cmd /usr/bin/printf args "#kept"\n'
+                "deny :blocked\n",
+                encoding="utf-8",
+            )
+            result = self._run_shell(
+                f"doas_read_rules {shlex.quote(str(config))}"
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("ignored", result.stdout)
+        self.assertNotIn("Soccer", result.stdout)
+        self.assertIn("permit nopass player as root cmd /usr/bin/dstat", result.stdout)
+        self.assertIn('args "#kept"', result.stdout)
+        self.assertIn("deny :blocked", result.stdout)
+
+    def test_doas_c_evaluation_never_runs_the_requested_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            fake_doas = tmp_path / "doas"
+            config = tmp_path / "doas.conf"
+            executed = tmp_path / "executed"
+            config.write_text(
+                "permit nopass player as root cmd /usr/bin/dstat\n",
+                encoding="utf-8",
+            )
+            fake_doas.write_text(
+                "#!/bin/sh\n"
+                "[ \"$1\" = -C ] || exit 20\n"
+                "[ -f \"$2\" ] || exit 21\n"
+                "if [ $# -eq 2 ]; then exit 0; fi\n"
+                "[ \"$3\" = /usr/bin/dstat ] || { echo deny; exit 1; }\n"
+                "echo 'permit nopass'\n",
+                encoding="utf-8",
+            )
+            fake_doas.chmod(0o755)
+
+            result = self._run_shell(
+                "\n".join(
+                    [
+                        "TIMEOUT=",
+                        f"doas_config_syntax_valid {shlex.quote(str(fake_doas))} {shlex.quote(str(config))} && echo syntax=ok",
+                        f"doas_check_command {shlex.quote(str(fake_doas))} {shlex.quote(str(config))} /usr/bin/dstat",
+                        f"[ ! -e {shlex.quote(str(executed))} ] && echo executed=no",
+                    ]
+                )
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("syntax=ok", result.stdout)
+        self.assertIn("permit nopass", result.stdout)
+        self.assertIn("executed=no", result.stdout)
+
+    def test_module_reports_the_soccer_configuration(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            fake_doas = tmp_path / "doas"
+            config = tmp_path / "doas.conf"
+            fake_doas.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            fake_doas.chmod(0o755)
+            config.write_text(
+                "permit nopass player as root cmd /usr/bin/dstat\n",
+                encoding="utf-8",
+            )
+
+            body = "\n".join(
+                [
+                    f"PATH={shlex.quote(str(tmp_path))}:$PATH",
+                    "export PATH",
+                    "E=E",
+                    "SED_RED='&'",
+                    "SED_RED_YELLOW='&'",
+                    "SED_LIGHT_CYAN='&'",
+                    "SED_GREEN='&'",
+                    "TIMEOUT=",
+                    "sudoVB1='dstat$'",
+                    "sudoVB2=''",
+                    "print_2title() { echo \"TITLE: $1\"; }",
+                    "print_3title() { echo \"SUBTITLE: $1\"; }",
+                    "print_info() { :; }",
+                    "echo_not_found() { echo \"NOT FOUND: $1\"; }",
+                    "id() {",
+                    "  case \"$1\" in",
+                    "    -un) echo player ;;",
+                    "    -u) echo 1000 ;;",
+                    "    -Gn) echo 'player users' ;;",
+                    "    -G) echo '1000 100' ;;",
+                    "    *) command id \"$@\" ;;",
+                    "  esac",
+                    "}",
+                    f". {shlex.quote(str(self.module_file))}",
+                ]
+            )
+            result = self._run_shell(body)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "matching permit rule allows GTFOBins-capable command /usr/bin/dstat as root without a password",
+            result.stdout,
+        )
+        self.assertIn("HTB Soccer privilege-escalation pattern", result.stdout)
+
+    def test_symlinked_binary_uses_target_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            real_doas = tmp_path / "doas-real"
+            linked_doas = tmp_path / "doas"
+            real_doas.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            real_doas.chmod(0o755)
+            linked_doas.symlink_to(real_doas)
+
+            body = "\n".join(
+                [
+                    f"PATH={shlex.quote(str(tmp_path))}:$PATH",
+                    "export PATH",
+                    "E=E",
+                    "SED_RED='&'",
+                    "SED_RED_YELLOW='&'",
+                    "SED_LIGHT_CYAN='&'",
+                    "SED_GREEN='&'",
+                    "TIMEOUT=",
+                    "sudoVB1=''",
+                    "sudoVB2=''",
+                    "print_2title() { :; }",
+                    "print_3title() { :; }",
+                    "print_info() { :; }",
+                    "echo_not_found() { :; }",
+                    "id() {",
+                    "  case \"$1\" in",
+                    "    -un) echo root ;;",
+                    "    -u) echo 0 ;;",
+                    "    -Gn) echo wheel ;;",
+                    "    -G) echo 0 ;;",
+                    "    *) command id \"$@\" ;;",
+                    "  esac",
+                    "}",
+                    f". {shlex.quote(str(self.module_file))}",
+                ]
+            )
+            result = self._run_shell(body)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("CRITICAL: doas is writable", result.stdout)
+
+    def test_module_replaces_invalid_doas_l_with_config_evaluation(self):
+        content = self.module_file.read_text(encoding="utf-8")
+        self.assertNotRegex(content, r"\bdoas\s+-l\b")
+        self.assertIn("doas_config_syntax_valid", content)
+        self.assertIn("doas_check_command", content)
+        self.assertIn("HTB Soccer", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- expand doas binary and configuration discovery across common installation paths
- detect writable or incorrectly owned binaries, configs, and config directories
- identify unrestricted, nopass, dangerous environment, and GTFOBins-capable root rules
- detect the HTB Soccer dstat plugin privilege-escalation pattern
- report relevant OpenDoas and portable doas CVE version ranges with distro-backport caveats
- replace the invalid doas -l probe with trust-gated, non-executing doas -C effective-rule checks
- add focused parser, safety, integration, and regression tests

## Testing

- sh -n on the doas module and helper
- python3 -m unittest linPEAS.tests.test_doas linPEAS.tests.test_modules_metadata (16 tests)
- python3 -m unittest linPEAS.tests.test_builder (11 tests)