### PR TITLE
fix(ci): pin working Chack Agent action

### DIFF
--- a/.github/workflows/chack-agent-pr-triage.yml
+++ b/.github/workflows/chack-agent-pr-triage.yml
@@ -131,7 +131,8 @@ jobs:
       - name: Run Chack Agent
         id: run_chack
         if: ${{ steps.gate.outputs.should_run == 'true' && steps.gate.outputs.trusted_automerge != 'true' }}
-        uses: carlospolop/chack-agent@master
+        # Pin the action so dependency changes on its default branch cannot break PR triage.
+        uses: carlospolop/chack-agent@9fd38a0657ae7060cc9bb07329c0bde71d7ba0d9
         with:
           provider: codex
           model_primary: BEST_QUALITY

--- a/.github/workflows/ci-master-failure-chack-agent-pr.yml
+++ b/.github/workflows/ci-master-failure-chack-agent-pr.yml
@@ -154,7 +154,8 @@ jobs:
 
       - name: Run Chack Agent
         id: run_chack
-        uses: carlospolop/chack-agent@master
+        # Pin the action so dependency changes on its default branch cannot break CI repair.
+        uses: carlospolop/chack-agent@9fd38a0657ae7060cc9bb07329c0bde71d7ba0d9
         with:
           provider: codex
           model_primary: BEST_QUALITY

--- a/.github/workflows/pr-failure-chack-agent-dispatch.yml
+++ b/.github/workflows/pr-failure-chack-agent-dispatch.yml
@@ -180,7 +180,8 @@ jobs:
 
       - name: Run Chack Agent
         id: run_chack
-        uses: carlospolop/chack-agent@master
+        # Pin the action so dependency changes on its default branch cannot break PR repair.
+        uses: carlospolop/chack-agent@9fd38a0657ae7060cc9bb07329c0bde71d7ba0d9
         with:
           provider: codex
           model_primary: BEST_QUALITY


### PR DESCRIPTION
## Summary

- pin every PEASS Chack Agent workflow to the repaired, tested action commit
- prevent future unreviewed changes on the action default branch from simultaneously breaking PR triage, PR failure repair, and master failure repair

## Root cause and upstream fix

MCP 2.0 removed mcp.server.fastmcp, causing the Chack stdio server to exit during Codex initialization. The shared action now constrains MCP below 2.0, performs a real subprocess handshake regression test, and fails GitHub Actions on backend errors instead of posting them as review comments.

Upstream fix: https://github.com/carlospolop/chack-agent/pull/32
Original failure: https://github.com/peass-ng/PEASS-ng/pull/676#issuecomment-5259635051

## Validation

- all workflow YAML parses successfully
- upstream focused suite: 42 passed
- upstream full suite: 692 passed, 8 skipped, 6 subtests passed