### PR TITLE
new-check(winpeas): add high-impact vulnerability detection

### DIFF
--- a/winPEAS/winPEASexe/Tests/SmokeTests.cs
+++ b/winPEAS/winPEASexe/Tests/SmokeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using winPEAS.Info.ServicesInfo;
 
 namespace winPEAS.Tests
 {
@@ -37,6 +38,27 @@ namespace winPEAS.Tests
                 Assert.Fail($"Exception thrown: {e.Message}");
             }
         }
+
+        [TestMethod]
+        public void ShouldNormalizeServiceDllPathsAndSystemAccount()
+        {
+            Assert.AreEqual(
+                @"C:\Windows\System32\example.dll",
+                ServicesInfoHelper.NormalizeServiceDllPath(@" ""%SystemRoot%\System32\example.dll"" ", @"C:\Windows"));
+            Assert.AreEqual(
+                @"C:\Windows\System32\example.dll",
+                ServicesInfoHelper.NormalizeServiceDllPath(@"\SystemRoot\System32\example.dll", @"C:\Windows"));
+            Assert.AreEqual(
+                @"C:\Windows\Sysnative\example.dll",
+                ServicesInfoHelper.GetFileSystemAccessPath(
+                    @"C:\Windows\System32\example.dll", @"C:\Windows", true, false));
+            Assert.AreEqual(
+                @"C:\Windows\System32\example.dll",
+                ServicesInfoHelper.GetFileSystemAccessPath(
+                    @"C:\Windows\System32\example.dll", @"C:\Windows", true, true));
+            Assert.IsTrue(ServicesInfoHelper.IsLocalSystemAccount(null));
+            Assert.IsTrue(ServicesInfoHelper.IsLocalSystemAccount(@"NT AUTHORITY\SYSTEM"));
+            Assert.IsFalse(ServicesInfoHelper.IsLocalSystemAccount(@"NT AUTHORITY\LocalService"));
+        }
     }
 }
-

--- a/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
@@ -12,11 +12,11 @@ namespace winPEAS.Checks
     {
         Dictionary<string, string> modifiableServices = new Dictionary<string, string>();
 
-        public string[] MitreAttackIds { get; } = new[] { "T1007", "T1543.003", "T1574.001", "T1574.011", "T1014", "T1068" };
+        public string[] MitreAttackIds { get; } = new[] { "T1007", "T1543.003", "T1574.001", "T1574.010", "T1574.011", "T1014", "T1068" };
 
         public void PrintInfo(bool isDebug)
         {
-            Beaprint.GreatPrint("Services Information", "T1007,T1543.003,T1574.001,T1574.011,T1014,T1068");
+            Beaprint.GreatPrint("Services Information", "T1007,T1543.003,T1574.001,T1574.010,T1574.011,T1014,T1068");
 
             /// Start finding Modifiable services so any function could use them
 
@@ -37,6 +37,7 @@ namespace winPEAS.Checks
                 PrintInterestingServices,
                 PrintModifiableServices,
                 PrintWritableRegServices,
+                PrintWritableSystemServiceDlls,
                 PrintPathDllHijacking,
                 PrintOemPrivilegedUtilities,
                 PrintLegacySignedKernelDrivers,
@@ -180,6 +181,49 @@ namespace winPEAS.Checks
                     foreach (Dictionary<string, string> writeServReg in regPerms)
                         Beaprint.AnsiPrint(string.Format("    {0} ({1})", writeServReg["Path"], writeServReg["Permissions"]), colorsWR);
 
+                }
+            }
+            catch (Exception ex)
+            {
+                Beaprint.PrintException(ex.Message);
+            }
+        }
+
+        void PrintWritableSystemServiceDlls()
+        {
+            try
+            {
+                Beaprint.MainPrint("Writable DLLs loaded by LocalSystem services", "T1574.010");
+                Beaprint.LinkPrint("https://attack.mitre.org/techniques/T1574/010/",
+                    "A writable service DLL or replacement-capable DLL directory can yield SYSTEM code execution when the service loads it");
+
+                List<ServicesInfoHelper.WritableServiceDllInfo> findings =
+                    ServicesInfoHelper.GetWritableSystemServiceDlls(Checks.CurrentUserSiDs);
+
+                if (findings.Count == 0)
+                {
+                    Beaprint.GoodPrint("    No writable DLL paths were found for enabled LocalSystem shared-process services.");
+                    return;
+                }
+
+                foreach (ServicesInfoHelper.WritableServiceDllInfo finding in findings)
+                {
+                    Beaprint.BadPrint($"    {finding.ServiceName} ({finding.Account})");
+                    Beaprint.NoColorPrint($"      ServiceDll : {finding.ServiceDllPath}");
+                    Beaprint.NoColorPrint($"      DLL exists : {finding.FileExists}");
+
+                    if (finding.FilePermissions.Count > 0)
+                    {
+                        Beaprint.BadPrint("      File ACL    : " + string.Join(", ", finding.FilePermissions));
+                    }
+
+                    if (finding.DirectoryPermissions.Count > 0)
+                    {
+                        string reason = finding.FileExists ? "replacement-capable directory ACL" : "writable directory can plant missing DLL";
+                        Beaprint.BadPrint($"      Folder ACL  : {string.Join(", ", finding.DirectoryPermissions)} ({reason})");
+                    }
+
+                    Beaprint.PrintLineSeparator();
                 }
             }
             catch (Exception ex)

--- a/winPEAS/winPEASexe/winPEAS/Info/ServicesInfo/ServicesInfoHelper.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ServicesInfo/ServicesInfoHelper.cs
@@ -382,6 +382,326 @@ namespace winPEAS.Info.ServicesInfo
         }
 
 
+        internal class WritableServiceDllInfo
+        {
+            public string ServiceName { get; set; }
+            public string Account { get; set; }
+            public string ServiceDllPath { get; set; }
+            public bool FileExists { get; set; }
+            public List<string> FilePermissions { get; set; }
+            public List<string> DirectoryPermissions { get; set; }
+        }
+
+
+        //////////////////////////////////////////////////////
+        //////// Writable LocalSystem service DLLs ///////////
+        //////////////////////////////////////////////////////
+        public static List<WritableServiceDllInfo> GetWritableSystemServiceDlls(Dictionary<string, string> currentUserSids)
+        {
+            var results = new List<WritableServiceDllInfo>();
+            if (currentUserSids == null || currentUserSids.Count == 0)
+            {
+                return results;
+            }
+
+            string windowsDirectory = Environment.GetEnvironmentVariable("SystemRoot");
+            if (string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                windowsDirectory = Environment.GetEnvironmentVariable("windir");
+            }
+
+            foreach (string serviceName in RegistryHelper.GetRegSubkeys("HKLM", @"SYSTEM\CurrentControlSet\Services"))
+            {
+                try
+                {
+                    string servicePath = @"SYSTEM\CurrentControlSet\Services\" + serviceName;
+                    Dictionary<string, object> serviceValues = RegistryHelper.GetRegValues("HKLM", servicePath);
+                    if (serviceValues == null)
+                    {
+                        continue;
+                    }
+
+                    int? serviceType = GetRegistryInt(serviceValues, "Type");
+                    int? startType = GetRegistryInt(serviceValues, "Start");
+                    if (!serviceType.HasValue || !startType.HasValue ||
+                        (serviceType.Value & 0x20) == 0 || (serviceType.Value & 0xC0) != 0 ||
+                        startType.Value == 4)
+                    {
+                        continue;
+                    }
+
+                    string account = GetRegistryString(serviceValues, "ObjectName");
+                    if (!IsLocalSystemAccount(account))
+                    {
+                        continue;
+                    }
+
+                    string rawServiceDll = GetUnexpandedServiceDll(servicePath + @"\Parameters");
+                    string serviceDllPath = NormalizeServiceDllPath(rawServiceDll, windowsDirectory);
+                    if (string.IsNullOrWhiteSpace(serviceDllPath) || serviceDllPath.IndexOf('%') >= 0 ||
+                        !IsLocalDrivePath(serviceDllPath))
+                    {
+                        continue;
+                    }
+
+                    string accessPath = GetFileSystemAccessPath(
+                        serviceDllPath,
+                        windowsDirectory,
+                        Environment.Is64BitOperatingSystem,
+                        Environment.Is64BitProcess);
+                    bool fileExists = File.Exists(accessPath);
+
+                    List<string> filePermissions = fileExists
+                        ? GetWritableFilePermissions(accessPath, currentUserSids)
+                            .Where(IsFileReplacementPermission)
+                            .ToList()
+                        : new List<string>();
+
+                    string directoryPath = Path.GetDirectoryName(accessPath);
+                    List<string> directoryPermissions = string.IsNullOrWhiteSpace(directoryPath)
+                        ? new List<string>()
+                        : GetAllowedPermissions(PermissionsHelper.GetPermissionsFolder(directoryPath, currentUserSids, PermissionType.WRITEABLE_OR_EQUIVALENT));
+
+                    directoryPermissions = fileExists
+                        ? directoryPermissions.Where(IsDirectoryReplacementPermission).ToList()
+                        : directoryPermissions.Where(IsDirectoryPlantPermission).ToList();
+
+                    if (filePermissions.Count == 0 && directoryPermissions.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    results.Add(new WritableServiceDllInfo
+                    {
+                        ServiceName = serviceName,
+                        Account = string.IsNullOrWhiteSpace(account) ? "LocalSystem" : account,
+                        ServiceDllPath = serviceDllPath,
+                        FileExists = fileExists,
+                        FilePermissions = filePermissions,
+                        DirectoryPermissions = directoryPermissions
+                    });
+                }
+                catch
+                {
+                    // A malformed or inaccessible service entry must not stop enumeration.
+                }
+            }
+
+            return results.OrderBy(result => result.ServiceName, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        internal static string NormalizeServiceDllPath(string rawPath, string windowsDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(rawPath))
+            {
+                return string.Empty;
+            }
+
+            string path = rawPath.Trim();
+            if (path.Length >= 2 && path[0] == '"' && path[path.Length - 1] == '"')
+            {
+                path = path.Substring(1, path.Length - 2).Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                path = ReplaceWindowsDirectoryPrefix(path, "%SystemRoot%", windowsDirectory);
+                path = ReplaceWindowsDirectoryPrefix(path, "%windir%", windowsDirectory);
+                path = ReplaceWindowsDirectoryPrefix(path, @"\SystemRoot", windowsDirectory);
+            }
+
+            if (path.StartsWith(@"\??\", StringComparison.Ordinal))
+            {
+                path = path.Substring(4);
+            }
+            else if (path.StartsWith(@"\\?\", StringComparison.Ordinal))
+            {
+                path = path.Substring(4);
+            }
+
+            return path.Trim();
+        }
+
+        internal static bool IsLocalSystemAccount(string account)
+        {
+            if (string.IsNullOrWhiteSpace(account))
+            {
+                return true;
+            }
+
+            string normalized = account.Trim();
+            return normalized.Equals("LocalSystem", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("SYSTEM", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals(@"NT AUTHORITY\SYSTEM", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals(@"NT AUTHORITY\LocalSystem", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string GetFileSystemAccessPath(string path, string windowsDirectory, bool is64BitOperatingSystem, bool is64BitProcess)
+        {
+            if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(windowsDirectory) ||
+                !is64BitOperatingSystem || is64BitProcess)
+            {
+                return path;
+            }
+
+            string system32Prefix = windowsDirectory.TrimEnd('\\', '/') + @"\System32\";
+            if (!path.StartsWith(system32Prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return path;
+            }
+
+            return windowsDirectory.TrimEnd('\\', '/') + @"\Sysnative\" + path.Substring(system32Prefix.Length);
+        }
+
+        private static string ReplaceWindowsDirectoryPrefix(string path, string prefix, string windowsDirectory)
+        {
+            if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                (path.Length > prefix.Length && path[prefix.Length] != '\\' && path[prefix.Length] != '/'))
+            {
+                return path;
+            }
+
+            return windowsDirectory.TrimEnd('\\', '/') + path.Substring(prefix.Length);
+        }
+
+        private static bool IsLocalDrivePath(string path)
+        {
+            // Do not touch UNC ServiceDll paths: this check must never initiate network access.
+            if (path.Length < 3 || !char.IsLetter(path[0]) || path[1] != ':' ||
+                (path[2] != '\\' && path[2] != '/'))
+            {
+                return false;
+            }
+
+            try
+            {
+                DriveType driveType = new System.IO.DriveInfo(path.Substring(0, 3)).DriveType;
+                return driveType != DriveType.Network && driveType != DriveType.NoRootDirectory;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string GetUnexpandedServiceDll(string parametersPath)
+        {
+            try
+            {
+                using (RegistryKey parametersKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(parametersPath))
+                {
+                    object value = parametersKey?.GetValue(
+                        "ServiceDll",
+                        null,
+                        RegistryValueOptions.DoNotExpandEnvironmentNames);
+                    return value == null ? string.Empty : value.ToString();
+                }
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static int? GetRegistryInt(Dictionary<string, object> values, string name)
+        {
+            object value = GetRegistryValue(values, name);
+            if (value == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return Convert.ToInt32(value);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetRegistryString(Dictionary<string, object> values, string name)
+        {
+            object value = GetRegistryValue(values, name);
+            return value == null ? string.Empty : value.ToString();
+        }
+
+        private static object GetRegistryValue(Dictionary<string, object> values, string name)
+        {
+            if (values == null)
+            {
+                return null;
+            }
+
+            foreach (KeyValuePair<string, object> entry in values)
+            {
+                if (entry.Key.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return entry.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static List<string> GetAllowedPermissions(IEnumerable<string> permissions)
+        {
+            return permissions == null
+                ? new List<string>()
+                : permissions.Where(permission =>
+                    permission.IndexOf("[Allow:", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                    permission.IndexOf("[Deny:", StringComparison.OrdinalIgnoreCase) < 0).ToList();
+        }
+
+        private static List<string> GetWritableFilePermissions(string path, Dictionary<string, string> currentUserSids)
+        {
+            try
+            {
+                FileSecurity security = File.GetAccessControl(path);
+                return GetAllowedPermissions(PermissionsHelper.GetMyPermissionsF(
+                    security,
+                    currentUserSids,
+                    PermissionType.WRITEABLE_OR_EQUIVALENT));
+            }
+            catch
+            {
+                return new List<string>();
+            }
+        }
+
+        private static bool IsFileReplacementPermission(string permission)
+        {
+            return permission.IndexOf("AllAccess", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("GenericAll", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("FullControl", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("GenericWrite", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("WriteData/CreateFiles", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("Modify", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("Write", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("TakeOwnership", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("ChangePermissions", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static bool IsDirectoryReplacementPermission(string permission)
+        {
+            return permission.IndexOf("AllAccess", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("GenericAll", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("FullControl", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("Modify", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("TakeOwnership", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("ChangePermissions", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static bool IsDirectoryPlantPermission(string permission)
+        {
+            return IsDirectoryReplacementPermission(permission) ||
+                   permission.IndexOf("GenericWrite", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("WriteData/CreateFiles", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   permission.IndexOf("Write", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+
         //////////////////////////////////////
         ////////  PATH DLL Hijacking /////////
         //////////////////////////////////////

--- a/winPEAS/winPEASexe/winPEAS/Properties/AssemblyInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("Tests")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1928358e-a64b-493f-a741-ae8e3d029374")]


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact winpeas vulnerability check. -->

Automated proposal for one new, high-impact `winpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS winpeas new-check agent completed successfully with 54 steps. Agent Comment: ERROR: Codex execution timed out after 900s.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
