### PR TITLE
new-check(linpeas): add high-impact vulnerability detection

### DIFF
--- a/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh
+++ b/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh
@@ -1,12 +1,12 @@
 # Title: Interesting Permissions Files - Capabilities
 # ID: IP_Capabilities
 # Author: Carlos Polop
-# Last Update: 22-08-2023
-# Description: Capabilities
+# Last Update: 14-08-2026
+# Description: Capabilities, including set-capabilities snap-confine exposure to CVE-2026-8933
 # License: GNU GPL
-# Version: 1.0
-# Mitre: T1548.001
-# Functions Used: echo_not_found, print_2title, print_info, print_3title
+# Version: 1.1
+# Mitre: T1548.001,T1068
+# Functions Used: checkSnapConfineCVE20268933, echo_not_found, print_2title, print_info, print_3title
 # Global Variables: $capsB, $capsVB, $IAMROOT, $SEARCH_IN_FOLDER
 # Initial Functions:
 # Generated Global Variables: $cap_name, $cap_value, $cap_line, $cap_status_file, $cap_default_sep, $cap_sep, $cap_color, $capVB, $capname, $capbins, $capsVB_vuln, $proc_status, $proc_pid, $proc_name, $proc_uid, $user_name, $proc_inh, $proc_prm, $proc_eff, $proc_bnd, $proc_amb, $proc_inh_dec, $proc_prm_dec, $proc_eff_dec, $proc_bnd_dec, $proc_amb_dec
@@ -125,4 +125,5 @@ if ! [ "$SEARCH_IN_FOLDER" ]; then
     fi
   done
   echo ""
+  checkSnapConfineCVE20268933
 fi

--- a/linPEAS/builder/linpeas_parts/functions/checkSnapConfineCVE20268933.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkSnapConfineCVE20268933.sh
@@ -1,0 +1,125 @@
+# Title: Functions - checkSnapConfineCVE20268933
+# ID: checkSnapConfineCVE20268933
+# Author: Chack Agent
+# Last Update: 14-08-2026
+# Description: Passively identify set-capabilities snap-confine binaries exposed to CVE-2026-8933.
+# License: GNU GPL
+# Version: 1.0
+# Mitre: T1068
+# Functions Used: print_3title, print_info
+# Global Variables: $E, $ROOT_FOLDER, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW
+# Initial Functions:
+# Generated Global Variables: $sc8933_caps, $sc8933_fixed, $sc8933_kind, $sc8933_os_id, $sc8933_os_release, $sc8933_path, $sc8933_reported, $sc8933_root, $sc8933_upstream, $sc8933_version, $sc8933_yaml
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+sc8933_extract_upstream_version() {
+  printf '%s' "$1" | sed -E 's/^[0-9]+://; s/^[^0-9]*//; s/[^0-9.].*$//'
+}
+
+sc8933_version_ge() {
+  [ -n "$1" ] && [ -n "$2" ] || return 1
+  if command -v dpkg >/dev/null 2>&1; then
+    dpkg --compare-versions "$1" ge "$2"
+  else
+    [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V 2>/dev/null | tail -n1)" = "$1" ]
+  fi
+}
+
+sc8933_version_lt() {
+  [ -n "$1" ] && [ -n "$2" ] || return 1
+  if command -v dpkg >/dev/null 2>&1; then
+    dpkg --compare-versions "$1" lt "$2"
+  else
+    [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V 2>/dev/null | head -n1)" = "$1" ]
+  fi
+}
+
+sc8933_version_is_vulnerable() {
+  sc8933_version="$1"
+  sc8933_kind="$2"
+  sc8933_os_release="$3"
+  sc8933_upstream="$(sc8933_extract_upstream_version "$sc8933_version")"
+
+  # The upstream affected range is >= 2.75.0 and < 2.76.1. Ubuntu fixed
+  # 2.76 with release-specific backports, so compare the complete dpkg version.
+  sc8933_version_ge "$sc8933_upstream" "2.75" || return 1
+  if [ "$sc8933_kind" = "deb" ]; then
+    sc8933_fixed=""
+    case "$sc8933_os_release" in
+      22.04) sc8933_fixed="2.76+ubuntu22.04.1" ;;
+      24.04) sc8933_fixed="2.76+ubuntu24.04.1" ;;
+      26.04) sc8933_fixed="2.76+ubuntu26.04.3" ;;
+    esac
+    if [ -n "$sc8933_fixed" ]; then
+      sc8933_version_lt "$sc8933_version" "$sc8933_fixed"
+      return
+    fi
+  fi
+
+  sc8933_version_lt "$sc8933_upstream" "2.76.1"
+}
+
+checkSnapConfineCVE20268933() {
+  command -v getcap >/dev/null 2>&1 || return
+
+  sc8933_root="${ROOT_FOLDER:-/}"
+  case "$sc8933_root" in
+    */) ;;
+    *) sc8933_root="${sc8933_root}/" ;;
+  esac
+  sc8933_os_id="$(sed -nE 's/^ID="?([^" ]+)"?$/\1/p' "${sc8933_root}etc/os-release" 2>/dev/null | head -n1)"
+  sc8933_os_release="$(sed -nE 's/^VERSION_ID="?([^" ]+)"?$/\1/p' "${sc8933_root}etc/os-release" 2>/dev/null | head -n1)"
+  sc8933_reported=""
+
+  for sc8933_path in \
+    "${sc8933_root}usr/lib/snapd/snap-confine" \
+    "${sc8933_root}snap/snapd/current/usr/lib/snapd/snap-confine"; do
+    [ -f "$sc8933_path" ] || continue
+    [ -u "$sc8933_path" ] && continue
+    sc8933_caps="$(getcap "$sc8933_path" 2>/dev/null)"
+    printf '%s' "$sc8933_caps" | grep -q 'cap_sys_admin' || continue
+
+    if [ -z "$sc8933_reported" ]; then
+      print_3title "Set-capabilities snap-confine (CVE-2026-8933)" "T1068"
+      print_info "https://ubuntu.com/security/CVE-2026-8933"
+      sc8933_reported="1"
+    fi
+
+    sc8933_kind="snap"
+    sc8933_yaml="${sc8933_root}snap/snapd/current/meta/snap.yaml"
+    sc8933_version=""
+    case "$sc8933_path" in
+      */usr/lib/snapd/snap-confine)
+        if [ "$sc8933_path" = "${sc8933_root}usr/lib/snapd/snap-confine" ]; then
+          sc8933_kind="deb"
+          if command -v dpkg-query >/dev/null 2>&1; then
+            sc8933_version="$(dpkg-query --admindir="${sc8933_root}var/lib/dpkg" -W -f='$''{Version}\n' snapd 2>/dev/null | head -n1)"
+          fi
+        elif [ -r "$sc8933_yaml" ]; then
+          sc8933_version="$(sed -nE "s/^version:[[:space:]]*['\"]?([^'\"[:space:]]+).*/\1/p" "$sc8933_yaml" 2>/dev/null | head -n1)"
+        fi
+        ;;
+    esac
+
+    echo "$sc8933_caps" | sed -${E} "s,.*,${SED_LIGHT_CYAN},"
+    if [ -z "$sc8933_version" ]; then
+      echo "Potential CVE-2026-8933 exposure: privileged snap-confine uses file capabilities; version could not be determined" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+    elif [ "$sc8933_os_id" != "ubuntu" ] && [ "$sc8933_kind" = "deb" ]; then
+      if sc8933_version_is_vulnerable "$sc8933_version" "$sc8933_kind" "$sc8933_os_release"; then
+        echo "snap-confine version $sc8933_version uses file capabilities and is in the upstream CVE-2026-8933 range; verify distro backports" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+      else
+        echo "snap-confine version $sc8933_version is not in the known CVE-2026-8933 vulnerable range" | sed -${E} "s,.*,${SED_GREEN},"
+      fi
+    elif sc8933_version_is_vulnerable "$sc8933_version" "$sc8933_kind" "$sc8933_os_release"; then
+      echo "Vulnerable to CVE-2026-8933: set-capabilities snap-confine version $sc8933_version permits local privilege escalation to root" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+    else
+      echo "snap-confine version $sc8933_version is not in the known CVE-2026-8933 vulnerable range" | sed -${E} "s,.*,${SED_GREEN},"
+    fi
+  done
+
+  if [ -n "$sc8933_reported" ]; then
+    echo ""
+  fi
+}

--- a/linPEAS/tests/test_snap_confine.py
+++ b/linPEAS/tests/test_snap_confine.py
@@ -1,0 +1,172 @@
+import os
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class SnapConfineCVE20268933Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[2]
+        cls.function_file = (
+            cls.repo_root
+            / "linPEAS"
+            / "builder"
+            / "linpeas_parts"
+            / "functions"
+            / "checkSnapConfineCVE20268933.sh"
+        )
+
+    def _make_root(self, base, release="24.04", snap_version=None):
+        root = base / "root"
+        (root / "etc").mkdir(parents=True)
+        (root / "etc" / "os-release").write_text(
+            f'ID=ubuntu\nVERSION_ID="{release}"\n', encoding="utf-8"
+        )
+        if snap_version is None:
+            binary = root / "usr" / "lib" / "snapd" / "snap-confine"
+        else:
+            binary = (
+                root
+                / "snap"
+                / "snapd"
+                / "current"
+                / "usr"
+                / "lib"
+                / "snapd"
+                / "snap-confine"
+            )
+            meta = root / "snap" / "snapd" / "current" / "meta"
+            meta.mkdir(parents=True)
+            (meta / "snap.yaml").write_text(
+                f"name: snapd\nversion: {snap_version}\n", encoding="utf-8"
+            )
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        binary.write_text("#!/bin/sh\ntouch \"$EXECUTED_MARKER\"\n", encoding="utf-8")
+        binary.chmod(0o755)
+        return root, binary
+
+    def _run_check(self, root, package_version="2.75+ubuntu24.04"):
+        bindir = root.parent / "bin"
+        bindir.mkdir()
+        getcap = bindir / "getcap"
+        getcap.write_text(
+            '#!/bin/sh\nprintf "%s cap_chown,cap_sys_admin=p\\n" "$1"\n',
+            encoding="utf-8",
+        )
+        getcap.chmod(0o755)
+        dpkg_query = bindir / "dpkg-query"
+        dpkg_query.write_text(
+            '#!/bin/sh\nprintf "%s\\n" "$FAKE_SNAPD_VERSION"\n', encoding="utf-8"
+        )
+        dpkg_query.chmod(0o755)
+
+        marker = root.parent / "executed"
+        env = os.environ.copy()
+        env.update(
+            {
+                "EXECUTED_MARKER": str(marker),
+                "FAKE_SNAPD_VERSION": package_version,
+                "PATH": f"{bindir}:{env['PATH']}",
+            }
+        )
+        body = "\n".join(
+            [
+                f"ROOT_FOLDER={shlex.quote(str(root))}",
+                "E=E",
+                "SED_RED_YELLOW='&'",
+                "SED_LIGHT_CYAN='&'",
+                "SED_GREEN='&'",
+                'print_3title() { echo "TITLE: $1"; }',
+                "print_info() { :; }",
+                f". {shlex.quote(str(self.function_file))}",
+                "checkSnapConfineCVE20268933",
+            ]
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result, marker
+
+    def test_vulnerable_ubuntu_package_is_reported_without_executing_binary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root, binary = self._make_root(Path(tmpdir))
+            result, marker = self._run_check(root)
+            self.assertFalse(marker.exists(), "the privileged binary must never be executed")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("TITLE: Set-capabilities snap-confine", result.stdout)
+        self.assertIn("Vulnerable to CVE-2026-8933", result.stdout)
+
+    def test_release_specific_fixed_versions(self):
+        cases = (
+            ("2.76+ubuntu22.04", "22.04", True),
+            ("2.76+ubuntu22.04.1", "22.04", False),
+            ("2.76+ubuntu24.04", "24.04", True),
+            ("2.76+ubuntu24.04.1", "24.04", False),
+            ("2.76+ubuntu26.04.2", "26.04", True),
+            ("2.76+ubuntu26.04.3", "26.04", False),
+            ("2.75.1", "snap", True),
+            ("2.76.1", "snap", False),
+        )
+        checks = []
+        for version, release, vulnerable in cases:
+            kind = "snap" if release == "snap" else "deb"
+            checks.append(
+                "sc8933_version_is_vulnerable "
+                f"{shlex.quote(version)} {kind} {release} && "
+                f"echo {version}=yes || echo {version}=no"
+            )
+        body = "\n".join(
+            [f". {shlex.quote(str(self.function_file))}"] + checks
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for version, _, vulnerable in cases:
+            expected = "yes" if vulnerable else "no"
+            self.assertIn(f"{version}={expected}", result.stdout)
+
+    def test_fixed_ubuntu_package_is_not_flagged(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root, binary = self._make_root(Path(tmpdir))
+            result, _ = self._run_check(root, package_version="2.76+ubuntu24.04.1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("not in the known CVE-2026-8933 vulnerable range", result.stdout)
+        self.assertNotIn("Vulnerable to CVE-2026-8933", result.stdout)
+
+    def test_vulnerable_snap_revision_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root, binary = self._make_root(Path(tmpdir), snap_version="2.75.1")
+            result, _ = self._run_check(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Vulnerable to CVE-2026-8933", result.stdout)
+        self.assertIn("version 2.75.1", result.stdout)
+
+    def test_setuid_snap_confine_is_excluded(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root, binary = self._make_root(Path(tmpdir))
+            binary.chmod(0o4755)
+            result, _ = self._run_check(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact linpeas vulnerability check. -->

Automated proposal for one new, high-impact `linpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS linpeas new-check agent completed successfully with 31 steps. Agent Comment: ## Implemented: CVE-2026-8933

Added one passive check for the high-severity `snap-confine` local privilege-escalation vulnerability. It can allow an unprivileged user to gain root on affected set-capabilities installations, including default Ubuntu Desktop configurations. Canonical rates it High/CVSS 7.8. [Canonical advisory](https://ubuntu.com/security/CVE-2026-8933), [Qualys technical advisory](https://cdn2.qualys.com/advisory/2026/07/21/snap-confine-set-capabilities.txt).

### Detection

The capabilities section now:

- Checks only the two canonical `snap-confine` paths.
- Requires file capabilities including `CAP_SYS_ADMIN`.
- Excludes setuid installations, which are not affected.
- Reads versions passively from `dpkg-query` or the mounted snap’s `meta/snap.yaml`.
- Handles upstream range `>=2.75, <2.76.1` and Ubuntu-specific fixed package versions from [USN-8579-1](https://ubuntu.com/security/notices/USN-8579-1).
- Never executes `snap-confine`, starts services, or modifies the system.

### Files changed

- `linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh`
- `linPEAS/builder/linpeas_parts/functions/checkSnapConfineCVE20268933.sh`
- `linPEAS/tests/test_snap_confine.py`

### Validation

All passed:

- `sh -n` for both modified shell files.
- `python3 -m unittest linPEAS.tests.test_modules_metadata` — 8 tests.
- `python3 -m unittest discover -s linPEAS/tests -p "test_*.py"` — 32 tests.
- Builder output to `/tmp/linpeas_new_check.sh`.
- Generated script syntax check.
- `git diff --check`.
- Verified the generated script contains exactly one helper definition, call, and user-visible title.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
