### PR TITLE
new-check(winpeas): add high-impact vulnerability detection

### DIFF
--- a/winPEAS/winPEASexe/Tests/RegistryHiveExposureTests.cs
+++ b/winPEAS/winPEASexe/Tests/RegistryHiveExposureTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using winPEAS.Info.FilesInfo;
+
+namespace winPEAS.Tests
+{
+    [TestClass]
+    public class RegistryHiveExposureTests
+    {
+        private static readonly HashSet<string> StandardUserSids = new HashSet<string>
+        {
+            "S-1-5-21-1000-1000-1000-1001",
+            "S-1-5-32-545",
+        };
+
+        [TestMethod]
+        public void DetectsBuiltInUsersReadAce()
+        {
+            var descriptor = new RawSecurityDescriptor("O:BAG:SYD:AI(A;ID;0x1200a9;;;BU)");
+
+            string trustee = RegistryHiveExposure.FindReadTrustee(descriptor, StandardUserSids);
+
+            Assert.AreEqual("S-1-5-32-545", trustee);
+        }
+
+        [TestMethod]
+        public void IgnoresAdministratorAndSystemOnlyAcl()
+        {
+            var descriptor = new RawSecurityDescriptor("O:BAG:SYD:AI(A;ID;FA;;;SY)(A;ID;FA;;;BA)");
+
+            string trustee = RegistryHiveExposure.FindReadTrustee(descriptor, StandardUserSids);
+
+            Assert.IsNull(trustee);
+        }
+
+        [TestMethod]
+        public void HonorsReadDenyBeforeAllow()
+        {
+            var descriptor = new RawSecurityDescriptor("O:BAG:SYD:(D;;FR;;;BU)(A;;FR;;;BU)");
+
+            string trustee = RegistryHiveExposure.FindReadTrustee(descriptor, StandardUserSids);
+
+            Assert.IsNull(trustee);
+        }
+
+        [TestMethod]
+        public void BuildsValidatedShadowHivePath()
+        {
+            string path = RegistryHiveExposure.BuildShadowHivePath(
+                @"\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy12",
+                @"C:\Windows",
+                "SECURITY");
+
+            Assert.AreEqual(
+                @"\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy12\Windows\System32\config\SECURITY",
+                path);
+            Assert.IsNull(RegistryHiveExposure.BuildShadowHivePath(@"\\server\share", @"C:\Windows", "SAM"));
+            Assert.IsNull(RegistryHiveExposure.BuildShadowHivePath(
+                @"\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy12",
+                @"C:\Windows",
+                @"..\SAM"));
+        }
+    }
+}

--- a/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
+++ b/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArgumentParsingTests.cs" />
+    <Compile Include="RegistryHiveExposureTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SmokeTests.cs" />
   </ItemGroup>

--- a/winPEAS/winPEASexe/winPEAS/Checks/FilesInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/FilesInfo.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using winPEAS.Helpers;
 using winPEAS.Helpers.Registry;
 using winPEAS.Helpers.Search;
+using winPEAS.Info.FilesInfo;
 using winPEAS.Info.FilesInfo.Certificates;
 using winPEAS.Info.FilesInfo.McAfee;
 using winPEAS.Info.FilesInfo.Office;
@@ -113,11 +114,11 @@ namespace winPEAS.Checks
         };
 
 
-        public string[] MitreAttackIds { get; } = new[] { "T1083", "T1552.001", "T1552.002", "T1552.004", "T1552.006", "T1003.002", "T1564.001", "T1574.001", "T1059.004", "T1114.001", "T1218", "T1649" };
+        public string[] MitreAttackIds { get; } = new[] { "T1083", "T1552.001", "T1552.002", "T1552.004", "T1552.006", "T1003.002", "T1003.004", "T1564.001", "T1574.001", "T1059.004", "T1114.001", "T1218", "T1649" };
 
         public void PrintInfo(bool isDebug)
         {
-            Beaprint.GreatPrint("Interesting files and registry", "T1083,T1552.001,T1552.002,T1552.004,T1552.006,T1003.002,T1564.001,T1574.001,T1059.004,T1114.001,T1218,T1649");
+            Beaprint.GreatPrint("Interesting files and registry", "T1083,T1552.001,T1552.002,T1552.004,T1552.006,T1003.002,T1003.004,T1564.001,T1574.001,T1059.004,T1114.001,T1218,T1649");
 
             new List<Action>
             {
@@ -197,17 +198,61 @@ namespace winPEAS.Checks
         {
             try
             {
-                Beaprint.MainPrint("Looking for common SAM & SYSTEM backups", "T1003.002");
-                List<string> sam_files = InterestingFiles.InterestingFiles.GetSAMBackups();
-                foreach (string path in sam_files)
-                {
-                    var permissions = PermissionsHelper.GetPermissionsFile(path, Checks.CurrentUserSiDs, PermissionType.READABLE_OR_WRITABLE);
+                Beaprint.MainPrint("Exposed SAM, SECURITY and SYSTEM registry hives", "T1003.002,T1003.004");
+                Beaprint.LinkPrint("https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36934",
+                    "CVE-2021-36934 (HiveNightmare): unsafe hive ACLs plus a readable VSS copy can expose credentials and enable SYSTEM escalation");
 
-                    if (permissions.Any())
+                RegistryHiveExposureReport report = RegistryHiveExposure.GetReport(
+                    InterestingFiles.InterestingFiles.GetRegistryHiveBackups());
+
+                const int maxFindingsToPrint = 20;
+                foreach (RegistryHiveExposureFinding finding in report.Findings.Take(maxFindingsToPrint))
+                {
+                    if (finding.Kind == RegistryHiveExposureKind.UnsafeLiveAcl)
                     {
-                        Beaprint.BadPrint("    " + path);
-                        Beaprint.BadPrint("    File Permissions: " + string.Join(", ", permissions) + "\n");
+                        Beaprint.BadPrint($"    Unsafe live hive ACL: {finding.Path}");
+                        Beaprint.BadPrint($"      Read access granted to enabled SID: {finding.Trustee}");
+                        Beaprint.GrayPrint("      Existing or future shadow copies may make this locked hive readable.");
                     }
+                    else
+                    {
+                        string source = finding.Kind == RegistryHiveExposureKind.ReadableShadowCopy
+                            ? "VSS shadow copy"
+                            : "backup";
+                        Beaprint.BadPrint($"    Readable {finding.HiveName} {source}: {finding.Path}");
+                        if (!string.IsNullOrEmpty(finding.Trustee))
+                        {
+                            Beaprint.BadPrint($"      File-data read access granted to unprivileged SID: {finding.Trustee}");
+                            Beaprint.GrayPrint("      The ACL was inspected; no hive contents were read.");
+                        }
+                        else
+                        {
+                            Beaprint.GrayPrint("      Access was verified by opening a read-only handle; no hive contents were read.");
+                        }
+                    }
+                }
+
+                if (report.Findings.Count == 0)
+                {
+                    Beaprint.GoodPrint("    No unsafe live hive ACLs or readable registry hive copies were found.");
+                }
+                else if (report.Findings.Count > maxFindingsToPrint)
+                {
+                    Beaprint.GrayPrint($"    Showing {maxFindingsToPrint}/{report.Findings.Count} registry hive exposures.");
+                }
+
+                if (report.ShadowCopyEnumerationSucceeded)
+                {
+                    string limitSuffix = report.ShadowCopyLimitReached ? " (scan limit reached)" : "";
+                    Beaprint.GrayPrint($"    VSS shadow copies checked: {report.ShadowCopiesChecked}{limitSuffix}");
+                }
+                else if (report.ShadowDeviceProbeUsed)
+                {
+                    Beaprint.GrayPrint($"    VSS WMI enumeration unavailable; probed {report.ShadowCopiesChecked} bounded device IDs.");
+                }
+                else
+                {
+                    Beaprint.GrayPrint("    VSS shadow copies could not be enumerated in the current context.");
                 }
             }
             catch (Exception ex)

--- a/winPEAS/winPEASexe/winPEAS/Info/FilesInfo/RegistryHiveExposure.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/FilesInfo/RegistryHiveExposure.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using winPEAS.Native;
+
+namespace winPEAS.Info.FilesInfo
+{
+    internal enum RegistryHiveExposureKind
+    {
+        UnsafeLiveAcl,
+        ReadableBackup,
+        ReadableShadowCopy,
+    }
+
+    internal sealed class RegistryHiveExposureFinding
+    {
+        public RegistryHiveExposureKind Kind { get; set; }
+        public string HiveName { get; set; }
+        public string Path { get; set; }
+        public string Trustee { get; set; }
+    }
+
+    internal sealed class RegistryHiveExposureReport
+    {
+        public List<RegistryHiveExposureFinding> Findings { get; } = new List<RegistryHiveExposureFinding>();
+        public int ShadowCopiesChecked { get; set; }
+        public bool ShadowCopyEnumerationSucceeded { get; set; }
+        public bool ShadowDeviceProbeUsed { get; set; }
+        public bool ShadowCopyLimitReached { get; set; }
+    }
+
+    internal static class RegistryHiveExposure
+    {
+        internal const int MaxShadowCopies = 64;
+
+        private const uint GenericRead = 0x80000000;
+        private const uint GenericAll = 0x10000000;
+        private const uint FileReadData = 0x00000001;
+        private const uint OpenExisting = 3;
+        private const uint ShareReadWriteDelete = 0x00000007;
+
+        private static readonly string[] HiveNames = { "SAM", "SECURITY", "SYSTEM" };
+        private const string ShadowDevicePrefix = @"\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy";
+
+        public static RegistryHiveExposureReport GetReport(IEnumerable<string> backupPaths)
+        {
+            var report = new RegistryHiveExposureReport();
+            string systemRoot = Environment.GetEnvironmentVariable("SystemRoot");
+            if (string.IsNullOrWhiteSpace(systemRoot))
+            {
+                return report;
+            }
+
+            bool isPrivilegedContext;
+            HashSet<string> unprivilegedSids = GetUnprivilegedTokenSids(out isPrivilegedContext);
+            CheckLiveHiveAcls(systemRoot, unprivilegedSids, report);
+            CheckBackupHives(backupPaths, unprivilegedSids, isPrivilegedContext, report);
+            CheckShadowCopies(systemRoot, unprivilegedSids, isPrivilegedContext, report);
+            return report;
+        }
+
+        private static void CheckLiveHiveAcls(
+            string systemRoot,
+            HashSet<string> unprivilegedSids,
+            RegistryHiveExposureReport report)
+        {
+            string displayConfigDirectory = Path.Combine(systemRoot, "System32", "config");
+            string accessSystemDirectory = Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess
+                ? "Sysnative"
+                : "System32";
+            string accessConfigDirectory = Path.Combine(systemRoot, accessSystemDirectory, "config");
+
+            foreach (string hiveName in HiveNames)
+            {
+                string hivePath = Path.Combine(displayConfigDirectory, hiveName);
+                string accessPath = Path.Combine(accessConfigDirectory, hiveName);
+                string trustee = GetReadTrustee(accessPath, unprivilegedSids);
+                if (!string.IsNullOrEmpty(trustee))
+                {
+                    report.Findings.Add(new RegistryHiveExposureFinding
+                    {
+                        Kind = RegistryHiveExposureKind.UnsafeLiveAcl,
+                        HiveName = hiveName,
+                        Path = hivePath,
+                        Trustee = trustee,
+                    });
+                }
+            }
+        }
+
+        private static void CheckBackupHives(
+            IEnumerable<string> backupPaths,
+            HashSet<string> unprivilegedSids,
+            bool isPrivilegedContext,
+            RegistryHiveExposureReport report)
+        {
+            if (backupPaths == null)
+            {
+                return;
+            }
+
+            foreach (string backupPath in backupPaths)
+            {
+                if (string.IsNullOrWhiteSpace(backupPath))
+                {
+                    continue;
+                }
+
+                string trustee = GetReadTrustee(backupPath, unprivilegedSids);
+                if (string.IsNullOrEmpty(trustee) && (isPrivilegedContext || !CanOpenForRead(backupPath)))
+                {
+                    continue;
+                }
+
+                report.Findings.Add(new RegistryHiveExposureFinding
+                {
+                    Kind = RegistryHiveExposureKind.ReadableBackup,
+                    HiveName = Path.GetFileName(backupPath),
+                    Path = backupPath,
+                    Trustee = trustee,
+                });
+            }
+        }
+
+        private static void CheckShadowCopies(
+            string systemRoot,
+            HashSet<string> unprivilegedSids,
+            bool isPrivilegedContext,
+            RegistryHiveExposureReport report)
+        {
+            try
+            {
+                using (var searcher = new ManagementObjectSearcher("SELECT DeviceObject FROM Win32_ShadowCopy"))
+                using (ManagementObjectCollection shadowCopies = searcher.Get())
+                {
+                    report.ShadowCopyEnumerationSucceeded = true;
+                    foreach (ManagementObject shadowCopy in shadowCopies)
+                    {
+                        if (report.ShadowCopiesChecked >= MaxShadowCopies)
+                        {
+                            report.ShadowCopyLimitReached = true;
+                            break;
+                        }
+
+                        string deviceObject = shadowCopy["DeviceObject"] as string;
+                        if (!IsExpectedShadowDevicePath(deviceObject))
+                        {
+                            continue;
+                        }
+
+                        CheckShadowDevice(deviceObject, systemRoot, unprivilegedSids, isPrivilegedContext, report);
+                    }
+                }
+            }
+            catch
+            {
+                // WMI is often restricted to administrators. Bounded device-name probing still
+                // verifies any snapshot that the current token can actually read.
+                report.ShadowCopyEnumerationSucceeded = false;
+                report.ShadowCopiesChecked = 0;
+                report.Findings.RemoveAll(finding => finding.Kind == RegistryHiveExposureKind.ReadableShadowCopy);
+                ProbeShadowDevices(systemRoot, unprivilegedSids, isPrivilegedContext, report);
+            }
+        }
+
+        private static void ProbeShadowDevices(
+            string systemRoot,
+            HashSet<string> unprivilegedSids,
+            bool isPrivilegedContext,
+            RegistryHiveExposureReport report)
+        {
+            report.ShadowDeviceProbeUsed = true;
+            for (int shadowNumber = 1; shadowNumber <= MaxShadowCopies; shadowNumber++)
+            {
+                string deviceObject = ShadowDevicePrefix + shadowNumber;
+                CheckShadowDevice(deviceObject, systemRoot, unprivilegedSids, isPrivilegedContext, report);
+            }
+
+            report.ShadowCopyLimitReached = true;
+        }
+
+        private static void CheckShadowDevice(
+            string deviceObject,
+            string systemRoot,
+            HashSet<string> unprivilegedSids,
+            bool isPrivilegedContext,
+            RegistryHiveExposureReport report)
+        {
+            report.ShadowCopiesChecked++;
+            foreach (string hiveName in HiveNames)
+            {
+                string hivePath = BuildShadowHivePath(deviceObject, systemRoot, hiveName);
+                if (string.IsNullOrEmpty(hivePath))
+                {
+                    continue;
+                }
+
+                string trustee = GetReadTrustee(hivePath, unprivilegedSids);
+                if (string.IsNullOrEmpty(trustee) && (isPrivilegedContext || !CanOpenForRead(hivePath)))
+                {
+                    continue;
+                }
+
+                report.Findings.Add(new RegistryHiveExposureFinding
+                {
+                    Kind = RegistryHiveExposureKind.ReadableShadowCopy,
+                    HiveName = hiveName,
+                    Path = hivePath,
+                    Trustee = trustee,
+                });
+            }
+        }
+
+        internal static string BuildShadowHivePath(string deviceObject, string systemRoot, string hiveName)
+        {
+            if (!IsExpectedShadowDevicePath(deviceObject) || string.IsNullOrWhiteSpace(systemRoot) ||
+                string.IsNullOrWhiteSpace(hiveName) || systemRoot.Length < 4 || systemRoot[1] != ':' ||
+                (systemRoot[2] != '\\' && systemRoot[2] != '/'))
+            {
+                return null;
+            }
+
+            string relativeWindowsDirectory = systemRoot.Substring(3).Trim('\\', '/');
+            if (string.IsNullOrWhiteSpace(relativeWindowsDirectory) || relativeWindowsDirectory.Contains("..") ||
+                hiveName.IndexOfAny(new[] { '\\', '/' }) >= 0)
+            {
+                return null;
+            }
+
+            return deviceObject.TrimEnd('\\') + "\\" + relativeWindowsDirectory.Replace('/', '\\') +
+                "\\System32\\config\\" + hiveName;
+        }
+
+        private static bool IsExpectedShadowDevicePath(string deviceObject)
+        {
+            if (string.IsNullOrWhiteSpace(deviceObject) ||
+                !deviceObject.StartsWith(ShadowDevicePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            string suffix = deviceObject.Substring(ShadowDevicePrefix.Length).TrimEnd('\\');
+            int shadowNumber;
+            return suffix.Length > 0 && int.TryParse(suffix, out shadowNumber) && shadowNumber >= 0;
+        }
+
+        private static bool CanOpenForRead(string path)
+        {
+            try
+            {
+                using (var handle = Kernel32.CreateFile(
+                    path,
+                    FileReadData,
+                    ShareReadWriteDelete,
+                    IntPtr.Zero,
+                    OpenExisting,
+                    0,
+                    IntPtr.Zero))
+                {
+                    // Opening the handle performs an effective access check; no hive bytes are read.
+                    return !handle.IsInvalid;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string GetReadTrustee(string path, ISet<string> unprivilegedSids)
+        {
+            try
+            {
+                FileSecurity security = File.GetAccessControl(path, AccessControlSections.Access);
+                var descriptor = new RawSecurityDescriptor(security.GetSecurityDescriptorBinaryForm(), 0);
+                return FindReadTrustee(descriptor, unprivilegedSids);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static HashSet<string> GetUnprivilegedTokenSids(out bool isPrivilegedContext)
+        {
+            var unprivilegedSids = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "S-1-1-0",      // Everyone
+                "S-1-5-4",      // Interactive
+                "S-1-5-11",     // Authenticated Users
+                "S-1-5-32-545", // BUILTIN\Users (the vulnerable CVE-2021-36934 ACE)
+            };
+            isPrivilegedContext = true;
+            try
+            {
+                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+                {
+                    var principal = new WindowsPrincipal(identity);
+                    var administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+                    isPrivilegedContext = principal.IsInRole(administratorsSid) ||
+                        (identity.User != null && IsPrivilegedServiceSid(identity.User.Value));
+                    if (!isPrivilegedContext && identity.User != null)
+                    {
+                        unprivilegedSids.Add(identity.User.Value);
+                    }
+
+                    if (identity.Groups != null)
+                    {
+                        foreach (IdentityReference group in identity.Groups)
+                        {
+                            var sid = group as SecurityIdentifier;
+                            if (sid != null && principal.IsInRole(sid) && !IsPrivilegedServiceSid(sid.Value) &&
+                                !sid.Equals(administratorsSid))
+                            {
+                                unprivilegedSids.Add(sid.Value);
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Keep the well-known unprivileged principals and avoid current-token open tests.
+            }
+
+            return unprivilegedSids;
+        }
+
+        private static bool IsPrivilegedServiceSid(string sid)
+        {
+            return string.Equals(sid, "S-1-5-18", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(sid, "S-1-5-19", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(sid, "S-1-5-20", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string FindReadTrustee(RawSecurityDescriptor descriptor, ISet<string> enabledSids)
+        {
+            if (descriptor == null || enabledSids == null || enabledSids.Count == 0)
+            {
+                return null;
+            }
+
+            if ((descriptor.ControlFlags & ControlFlags.DiscretionaryAclPresent) == 0 ||
+                descriptor.DiscretionaryAcl == null)
+            {
+                return enabledSids.Contains("S-1-1-0") ? "S-1-1-0" : null;
+            }
+
+            foreach (GenericAce ace in descriptor.DiscretionaryAcl)
+            {
+                if ((ace.AceFlags & AceFlags.InheritOnly) != 0)
+                {
+                    continue;
+                }
+
+                var qualifiedAce = ace as QualifiedAce;
+                var knownAce = ace as KnownAce;
+                if (qualifiedAce == null || knownAce == null || qualifiedAce.SecurityIdentifier == null ||
+                    !enabledSids.Contains(qualifiedAce.SecurityIdentifier.Value) || !GrantsFileReadData(knownAce.AccessMask))
+                {
+                    continue;
+                }
+
+                if (qualifiedAce.AceQualifier == AceQualifier.AccessDenied)
+                {
+                    return null;
+                }
+
+                if (qualifiedAce.AceQualifier == AceQualifier.AccessAllowed)
+                {
+                    return qualifiedAce.SecurityIdentifier.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool GrantsFileReadData(int accessMask)
+        {
+            uint mask = unchecked((uint)accessMask);
+            return (mask & FileReadData) != 0 || (mask & GenericRead) != 0 || (mask & GenericAll) != 0;
+        }
+    }
+}

--- a/winPEAS/winPEASexe/winPEAS/InterestingFiles/InterestingFiles.cs
+++ b/winPEAS/winPEASexe/winPEAS/InterestingFiles/InterestingFiles.cs
@@ -10,7 +10,7 @@ namespace winPEAS.InterestingFiles
 {
     internal static class InterestingFiles
     {
-        public static List<string> GetSAMBackups()
+        public static List<string> GetRegistryHiveBackups()
         {
             //From SharpUP
             var results = new List<string>();
@@ -18,15 +18,17 @@ namespace winPEAS.InterestingFiles
             try
             {
                 string systemRoot = Environment.GetEnvironmentVariable("SystemRoot");
-                string[] searchLocations =
-                {
-                    $@"{systemRoot}\repair\SAM",
-                    $@"{systemRoot}\System32\config\RegBack\SAM",
-                    //$@"{0}\System32\config\SAM"
-                    $@"{systemRoot}\repair\SYSTEM",
-                    //$@"{0}\System32\config\SYSTEM", systemRoot),
-                    $@"{systemRoot}\System32\config\RegBack\SYSTEM",
-                };
+                string systemDirectory = Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess
+                    ? "Sysnative"
+                    : "System32";
+                string[] hiveNames = { "SAM", "SECURITY", "SYSTEM" };
+                string[] searchLocations = hiveNames
+                    .SelectMany(hiveName => new[]
+                    {
+                        $@"{systemRoot}\repair\{hiveName}",
+                        $@"{systemRoot}\{systemDirectory}\config\RegBack\{hiveName}",
+                    })
+                    .ToArray();
 
                 results.AddRange(searchLocations.Where(searchLocation => File.Exists(searchLocation)));
             }

--- a/winPEAS/winPEASexe/winPEAS/Native/Kernel32.cs
+++ b/winPEAS/winPEASexe/winPEAS/Native/Kernel32.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -96,6 +97,16 @@ namespace winPEAS.Native
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern unsafe int GetFullPathName(string lpFileName, int nBufferLength, [Out, MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpBuffer, [Out, MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpFilePart);
+
+        [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern SafeFileHandle CreateFile(
+            string fileName,
+            uint desiredAccess,
+            uint shareMode,
+            IntPtr securityAttributes,
+            uint creationDisposition,
+            uint flagsAndAttributes,
+            IntPtr templateFile);
 
     }
 }

--- a/winPEAS/winPEASexe/winPEAS/Properties/AssemblyInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("Tests")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1928358e-a64b-493f-a741-ae8e3d029374")]

--- a/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
+++ b/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
@@ -1259,6 +1259,7 @@
     <Compile Include="Info\FilesInfo\Office\OfficeRecentFileInfo.cs" />
     <Compile Include="Info\FilesInfo\Office\OneDrive\CloudSyncProviderInfo.cs" />
     <Compile Include="Info\FilesInfo\Office\OneDrive\OneDriveSyncProviderInfo.cs" />
+    <Compile Include="Info\FilesInfo\RegistryHiveExposure.cs" />
     <Compile Include="Info\FilesInfo\WSL\WSLHelper.cs" />
     <Compile Include="Info\NetworkInfo\Enums\IPVersion.cs" />
     <Compile Include="Info\NetworkInfo\Enums\MibTcpState.cs" />


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact winpeas vulnerability check. -->

Automated proposal for one new, high-impact `winpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS winpeas new-check agent completed successfully with 44 steps. Agent Comment: ## Implemented check

**Exposed SAM/SECURITY/SYSTEM registry hives**, including **CVE-2021-36934 (HiveNightmare/SeriousSAM)**.

This is exceptionally relevant because it enables credential theft and potential SYSTEM escalation, and CISA lists it as known exploited. CERT/CC confirms the decisive evidence: unprivileged hive ACLs combined with readable VSS copies. [CISA](https://www.cisa.gov/news-events/alerts/2022/02/10/cisa-adds-15-known-exploited-vulnerabilities-catalog), [CERT/CC](https://kb.cert.org/vuls/id/506989), [Microsoft MSRC](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36934).

### Detection behavior

The existing SAM backup check now:

- Audits live `SAM`, `SECURITY`, and `SYSTEM` ACLs for enabled unprivileged SIDs.
- Honors deny-before-allow ACL semantics.
- Checks conventional `repair` and `RegBack` copies, including `SECURITY`.
- Enumerates up to 64 VSS snapshots, with bounded device-path probing when WMI is unavailable.
- Handles 32-bit winPEAS on 64-bit Windows through `Sysnative`.
- Uses ACL inspection or a read-only handle without reading or displaying hive contents.
- Avoids treating normal administrator-only access as an exposure.
- Caps displayed findings at 20.

### Files changed

- `Checks/FilesInfo.cs`
- `Info/FilesInfo/RegistryHiveExposure.cs`
- `InterestingFiles/InterestingFiles.cs`
- `Native/Kernel32.cs`
- `Properties/AssemblyInfo.cs`
- `winPEAS.csproj`
- `Tests/RegistryHiveExposureTests.cs`
- `Tests/winPEAS.Tests.csproj`

Focused tests cover vulnerable/fixed ACLs, deny precedence, and validated VSS path construction.

### Validation

- `git diff --check`: passed.
- Project XML parsing and compile-item existence/uniqueness: passed.
- Changed-file scope and delimiter/static checks: passed.
- Reviewed history, remote branches, and open PRs; no duplicate HiveNightmare check found.
- MSBuild/MSTest were not run because no compatible .NET Framework build tool is installed in this environment. Windows CI remains authoritative.

Additional impact reference: [MITRE ATT&CK T1003.002](https://attack.mitre.org/techniques/T1003/002/).

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
