### PR TITLE
wordlist-updater: refresh linpeas vulnerability lists

### DIFF
--- a/linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh
+++ b/linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh
@@ -1,13 +1,13 @@
 # Title: Function - kernel_cve_registry_checks
 # ID: kernel_cve_registry_checks
 # Author: Carlos Polop
-# Last Update: 28-06-2026
+# Last Update: 17-08-2026
 # Description: Evaluate declared kernel CVE rules using kernel version, arch, kernel config, sysctl and command prerequisites.
-# Description: Data source chunks KERNEL_CVE_DATA_1..22 are capped to 25 rows each.
+# Description: Data source chunks KERNEL_CVE_DATA_1..23 are capped to 25 rows each.
 # License: GNU GPL
 # Version: 1.0
 # Functions Used: echo_not_found, print_3title, print_list
-# Global Variables: $E, $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $SED_GREEN, $SED_RED_YELLOW
+# Global Variables: $E, $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $KERNEL_CVE_DATA_23, $SED_GREEN, $SED_RED_YELLOW
 # Initial Functions: echo_not_found, print_3title, print_list
 # Generated Global Variables: $KERNEL_CVE_CFG_FILE, $KERNEL_CVE_CFG_SOURCE, $KERNEL_CVE_CFG_LINE, $KERNEL_CVE_CFG_KEY, $KERNEL_CVE_CFG_EXPR, $KERNEL_CVE_CFG_EXPECT, $KERNEL_CVE_CFG_OP, $KERNEL_CVE_CFG_CUR, $KERNEL_CVE_SYS_EXPR, $KERNEL_CVE_SYS_KEY, $KERNEL_CVE_SYS_OP, $KERNEL_CVE_SYS_VAL, $KERNEL_CVE_SYS_CUR, $KERNEL_CVE_REQS, $KERNEL_CVE_REQ, $KERNEL_CVE_REQ_LINES, $KERNEL_CVE_ID, $KERNEL_CVE_ID_NORM, $KERNEL_CVE_NAME, $KERNEL_CVE_TAGS, $KERNEL_CVE_RANK, $KERNEL_CVE_COMMENTS, $KERNEL_CVE_EXPL, $KERNEL_CVE_VERS, $KERNEL_CVE_VER_LINES, $KERNEL_CVE_ALT, $KERNEL_CVE_MIL, $KERNEL_CVE_TOKEN_OK, $KERNEL_CVE_MATCHES, $KERNEL_CVE_KERNEL_RELEASE, $KERNEL_CVE_KERNEL_VERSION, $KERNEL_CVE_KERNEL_ARCH, $KERNEL_CVE_KERNEL_OS, $KERNEL_CVE_VER, $KERNEL_CVE_OP, $KERNEL_CVE_REQVER, $KERNEL_CVE_CURVER, $KERNEL_CVE_CMP, $KERNEL_CVE_PRINT_ID, $KERNEL_CVE_PRINT_REASON, $KERNEL_CVE_ID_RAW, $KERNEL_CVE_ID_ITEM, $KERNEL_CVE_ID_OUT, $KERNEL_CVE_ALL_DATA, $KERNEL_CVE_PRINT_LINE
 # Fat linpeas: 0
@@ -257,17 +257,17 @@ kercve_run_registry() {
         fi
     done
 
-    KERNEL_CVE_ALL_DATA=$(printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s" \
+    KERNEL_CVE_ALL_DATA=$(printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s" \
         "$KERNEL_CVE_DATA_1" "$KERNEL_CVE_DATA_2" "$KERNEL_CVE_DATA_3" "$KERNEL_CVE_DATA_4" "$KERNEL_CVE_DATA_5" \
         "$KERNEL_CVE_DATA_6" "$KERNEL_CVE_DATA_7" "$KERNEL_CVE_DATA_8" "$KERNEL_CVE_DATA_9" "$KERNEL_CVE_DATA_10" \
         "$KERNEL_CVE_DATA_11" "$KERNEL_CVE_DATA_12" "$KERNEL_CVE_DATA_13" "$KERNEL_CVE_DATA_14" "$KERNEL_CVE_DATA_15" \
         "$KERNEL_CVE_DATA_16" "$KERNEL_CVE_DATA_17" "$KERNEL_CVE_DATA_18" "$KERNEL_CVE_DATA_19" "$KERNEL_CVE_DATA_20" \
-        "$KERNEL_CVE_DATA_21" "$KERNEL_CVE_DATA_22")
+        "$KERNEL_CVE_DATA_21" "$KERNEL_CVE_DATA_22" "$KERNEL_CVE_DATA_23")
 
     print_list "Operating system ............. $KERNEL_CVE_KERNEL_OS\n"
     print_list "Kernel release ............... $KERNEL_CVE_KERNEL_RELEASE\n"
     print_list "Comparable version ........... $KERNEL_CVE_KERNEL_VERSION\n"
-    print_list "Data chunk limit ............. max 25 rows per KERNEL_CVE_DATA_* variable (1..22)\n"
+    print_list "Data chunk limit ............. max 25 rows per KERNEL_CVE_DATA_* variable (1..23)\n"
     if [ -n "$KERNEL_CVE_CFG_SOURCE" ]; then
         print_list "Kernel config source ......... $KERNEL_CVE_CFG_SOURCE\n"
     else

--- a/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
+++ b/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
@@ -2,14 +2,14 @@
 # ID: kernel_cve_registry_data
 # Author: Carlos Polop
 # Contributor: Arjay Saguisa
-# Last Update: 06-07-2026
+# Last Update: 17-08-2026
 # Description: Embedded kernel exploit matching datasets extracted from linux-exploit-suggester and linux-exploit-suggester-2 examples. Data is split across KERNEL_CVE_DATA_1..X with a maximum of 25 rows per env variable. This file also stores reference-only CVE tokens found in example repos when no explicit suggester matching rule exists.
 # License: GNU GPL
 # Version: 1.0
 # Functions Used:
 # Global Variables:
 # Initial Functions:
-# Generated Global Variables: $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22
+# Generated Global Variables: $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $KERNEL_CVE_DATA_23
 # Fat linpeas: 0
 # Small linpeas: 1
 
@@ -650,4 +650,27 @@ CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=6.7,ver<6.12.89,cmd:[ "$(c
 CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=6.13,ver<6.18.31,cmd:[ "$(cat /proc/sys/kernel/yama/ptrace_scope 2>/dev/null || echo 0)" -lt 2 ]		1	Upstream issue introduced in 4.10; fixed in 6.18.31; mitigated by kernel.yama.ptrace_scope >= 2
 CVE-2026-46333	ptrace exit-race	pkg=linux-kernel,ver>=6.19,ver<7.0.8,cmd:[ "$(cat /proc/sys/kernel/yama/ptrace_scope 2>/dev/null || echo 0)" -lt 2 ]		1	Upstream issue introduced in 4.10; fixed in 7.0.8; mitigated by kernel.yama.ptrace_scope >= 2
 EOF_DATA_22
+)"
+
+KERNEL_CVE_DATA_23="$(cat <<'EOF_DATA_23'
+CVE-2026-43499	GhostLock rtmutex UAF	pkg=linux-kernel,ver>=2.6.39,ver<5.10.261,CONFIG_FUTEX_PI=y		1	Fixed in stable 5.10.261; priority-inheritance futexes must be enabled
+CVE-2026-43499	GhostLock rtmutex UAF	pkg=linux-kernel,ver>=5.11,ver<5.15.212,CONFIG_FUTEX_PI=y		1	Fixed in stable 5.15.212; priority-inheritance futexes must be enabled
+CVE-2026-43499	GhostLock rtmutex UAF	pkg=linux-kernel,ver>=5.16,ver<6.1.175,CONFIG_FUTEX_PI=y		1	Fixed in stable 6.1.175; priority-inheritance futexes must be enabled
+CVE-2026-43499	GhostLock rtmutex UAF	pkg=linux-kernel,ver>=6.2,ver<6.6.140,CONFIG_FUTEX_PI=y		1	Fixed in stable 6.6.140; priority-inheritance futexes must be enabled
+CVE-2026-43499	GhostLock rtmutex UAF	pkg=linux-kernel,ver>=6.7,ver<6.12.86,CONFIG_FUTEX_PI=y		1	Fixed in stable 6.12.86; priority-inheritance futexes must be enabled
+CVE-2026-43499	GhostLock rtmutex UAF	pkg=linux-kernel,ver>=6.13,ver<6.18.27,CONFIG_FUTEX_PI=y		1	Fixed in stable 6.18.27; priority-inheritance futexes must be enabled
+CVE-2026-43499	GhostLock rtmutex UAF	pkg=linux-kernel,ver>=6.19,ver<7.0.4,CONFIG_FUTEX_PI=y		1	Fixed in stable 7.0.4 and mainline 7.1; priority-inheritance futexes must be enabled
+CVE-2026-53362	IPv6 fraggap out-of-bounds write	pkg=linux-kernel,ver>=6.0,ver<6.1.177,CONFIG_IPV6=[my]		1	Fixed in stable 6.1.177; IPv6 must be enabled
+CVE-2026-53362	IPv6 fraggap out-of-bounds write	pkg=linux-kernel,ver>=6.2,ver<6.6.144,CONFIG_IPV6=[my]		1	Fixed in stable 6.6.144; IPv6 must be enabled
+CVE-2026-53362	IPv6 fraggap out-of-bounds write	pkg=linux-kernel,ver>=6.7,ver<6.12.95,CONFIG_IPV6=[my]		1	Fixed in stable 6.12.95; IPv6 must be enabled
+CVE-2026-53362	IPv6 fraggap out-of-bounds write	pkg=linux-kernel,ver>=6.13,ver<6.18.38,CONFIG_IPV6=[my]		1	Fixed in stable 6.18.38; IPv6 must be enabled
+CVE-2026-53362	IPv6 fraggap out-of-bounds write	pkg=linux-kernel,ver>=6.19,ver<7.1.3,CONFIG_IPV6=[my]		1	Fixed in stable 7.1.3 and mainline 7.2-rc1; IPv6 must be enabled
+CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=4.11,ver<5.15.212,CONFIG_XFS_FS=[my],cmd:grep -qw xfs /proc/mounts		1	Fixed in stable 5.15.212; requires an XFS filesystem with reflink enabled
+CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=5.16,ver<6.1.178,CONFIG_XFS_FS=[my],cmd:grep -qw xfs /proc/mounts		1	Fixed in stable 6.1.178; requires an XFS filesystem with reflink enabled
+CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=6.2,ver<6.6.145,CONFIG_XFS_FS=[my],cmd:grep -qw xfs /proc/mounts		1	Fixed in stable 6.6.145; requires an XFS filesystem with reflink enabled
+CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=6.7,ver<6.12.96,CONFIG_XFS_FS=[my],cmd:grep -qw xfs /proc/mounts		1	Fixed in stable 6.12.96; requires an XFS filesystem with reflink enabled
+CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=6.13,ver<6.18.39,CONFIG_XFS_FS=[my],cmd:grep -qw xfs /proc/mounts		1	Fixed in stable 6.18.39; requires an XFS filesystem with reflink enabled
+CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=6.19,ver<7.1.4,CONFIG_XFS_FS=[my],cmd:grep -qw xfs /proc/mounts		1	Fixed in stable 7.1.4; requires an XFS filesystem with reflink enabled
+CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=7.2,ver<7.3,CONFIG_XFS_FS=[my],cmd:uname -r 2>/dev/null | grep -Eq '^7\.2\.0-rc[123]([-.]|$)',cmd:grep -qw xfs /proc/mounts		1	Fixed in mainline 7.2-rc4; requires an XFS filesystem with reflink enabled
+EOF_DATA_23
 )"


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Refreshed LinPEAS vulnerability wordlists. -->\n\nAutomated LinPEAS vulnerability wordlist refresh.\n\nAgent summary:\nPEASS linpeas wordlist updater completed successfully with 42 steps. Agent Comment: ### Files updated
- `linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh`
  - Added `KERNEL_CVE_DATA_23` with 19 branch-specific rules:
    - 7 × [CVE-2026-43499](https://www.cve.org/CVERecord?id=CVE-2026-43499) GhostLock
    - 5 × [CVE-2026-53362](https://www.cve.org/CVERecord?id=CVE-2026-53362) IPv6 fraggap
    - 7 × [CVE-2026-64600](https://www.cve.org/CVERecord?id=CVE-2026-64600) RefluXFS
  - Included relevant kernel-config, mounted-filesystem, and fixed-version boundaries.
- `linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh`
  - Mechanically registered chunk 23; no new check logic.

### Unchanged
- `sidB.sh`: no reliable SUID-applicable update found.
- `sudovB.sh`: retained the intentional August 3 fix covering sudo 1.9.17p1/p2; no newer [official sudo advisory](https://www.sudo.ws/security/advisories/) boundary found.
- CVE-2026-53166 was excluded because its CNA record is rejected.

### Validation
- LinPEAS build succeeded with exit code `0`.
- Output: `/tmp/linpeas_fat.sh` (1.1 MB).
- Generated script passed `sh -n` and contains all 19 new rows.
- `git diff --check` passed.
- Supplementary pytest was unavailable because `pytest` is not installed.\n\nGenerated by PEASS wordlist updater workflow.